### PR TITLE
Fix compilation on musl libc

### DIFF
--- a/src/vkey.hpp
+++ b/src/vkey.hpp
@@ -206,6 +206,7 @@ Unicode code point entry:
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <sys/select.h>
 
 #endif
 


### PR DESCRIPTION
Add missing include which fixes compilation on musl-based distributions (Void, Alpine, KISS, ...)