### PR TITLE
Disable march=native for SSE2

### DIFF
--- a/configure
+++ b/configure
@@ -7708,7 +7708,7 @@ $as_echo "no" >&6; }
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CXX} supports SSE2 intrinsics" >&5
 $as_echo_n "checking whether ${CXX} supports SSE2 intrinsics... " >&6; }
   save_CXXFLAGS=$CXXFLAGS
-  CXXFLAGS="-march=native"
+  CXXFLAGS="-msse2"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <emmintrin.h>
@@ -7730,7 +7730,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $msse2_ok" >&5
 $as_echo "$msse2_ok" >&6; }
   if test "x$msse2_ok" = "xyes"; then
-    SIMD_FLAGS="-march=native -msse2 -DHAVE_SSE2"
+    SIMD_FLAGS="-msse2 -DHAVE_SSE2"
   fi
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -190,14 +190,14 @@ if test "x$with_no_sse2" = "xno"; then
   AC_MSG_RESULT(no)
   AC_MSG_CHECKING([whether ${CXX} supports SSE2 intrinsics])
   save_CXXFLAGS=$CXXFLAGS
-  CXXFLAGS="-march=native"
+  CXXFLAGS="-msse2"
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <emmintrin.h>]], [[__m128i n = _mm_set1_epi8(42);]])],
                     [msse2_ok=yes],
                     [msse2_ok=no])
   CXXFLAGS=$save_CXXFLAGS
   AC_MSG_RESULT($msse2_ok)
   if test "x$msse2_ok" = "xyes"; then
-    SIMD_FLAGS="-march=native -msse2 -DHAVE_SSE2"
+    SIMD_FLAGS="-msse2 -DHAVE_SSE2"
   fi
 else
   AC_MSG_RESULT(yes)


### PR DESCRIPTION
Without this patch, the code would only build binaries with SSE2,
if the build machine CPU supported SSE2.

And through the `-march=native` flag, it would then use more CPU features
available on the build CPU that might not be available
on the target machine CPU. That can cause an illegal instruction
exception on the target machine.

This patch changes behaviour so that only configure options determine the
result of the build, regarding SSE2.

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on reproducible builds for openSUSE.

note that there are similar issues around AVX and neon extensions, but they are more tricky to resolve. e.g. the AVX test needs `-avx2` for some reason and maybe avx512 should be decoupled.
Maybe an option for compile-time detection is wanted there by some users?