### PR TITLE
vkey: Fix build on hurd-i386

### DIFF
--- a/src/query.cpp
+++ b/src/query.cpp
@@ -632,7 +632,7 @@ void Query::query()
 {
   get_stdin();
 
-  if (!VKey::setup(VKey::RAW))
+  if (!VKey::setup(VKey::TTYRAW))
     abort("no keyboard detected");
 
   if (!Screen::setup("ugrep --query"))

--- a/src/vkey.cpp
+++ b/src/vkey.cpp
@@ -752,7 +752,7 @@ void VKey::flush()
 #endif
 }
 
-// setup vkey in VKey::NORMAL tty or VKey::RAW raw tty mode (cfmakeraw), returns 0 on success <0 on failure
+// setup vkey in VKey::NORMAL tty or VKey::TTYRAW raw tty mode (cfmakeraw), returns 0 on success <0 on failure
 bool VKey::setup(int mode)
 {
 #ifdef OS_WIN
@@ -767,7 +767,7 @@ bool VKey::setup(int mode)
 
   DWORD inMode = oldInMode & ~(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT);
 
-  if (mode == VKey::RAW)
+  if (mode == VKey::TTYRAW)
     inMode &= ~ENABLE_PROCESSED_INPUT;
 
   // get event when window is resized
@@ -801,7 +801,7 @@ bool VKey::setup(int mode)
   tcgetattr(tty, &oldterm);
   tcgetattr(tty, &newterm);
 
-  if (mode == VKey::RAW)
+  if (mode == VKey::TTYRAW)
     cfmakeraw(&newterm);
   else
     newterm.c_lflag &= ~(ECHO | ICANON);

--- a/src/vkey.hpp
+++ b/src/vkey.hpp
@@ -215,7 +215,7 @@ class VKey {
  public:
 
   static const int NORMAL   = 0;   // VKey::setup in tty normal mode
-  static const int RAW      = 1;   // VKey::setup in tty raw mode (cfmakeraw)
+  static const int TTYRAW   = 1;   // VKey::setup in tty raw mode (cfmakeraw)
 
   static const int META     = 31;  // META/ALT/OPTION/CTRL-_
 
@@ -259,7 +259,7 @@ class VKey {
     return 255 + '@' + num;        // FN1..FN12 is 256+'A'..256+'L'
   }
 
-  // setup vkey in VKey::NORMAL tty or VKey::RAW raw tty mode (cfmakeraw), returns 0 on success <0 on failure
+  // setup vkey in VKey::NORMAL tty or VKey::TTYRAW raw tty mode (cfmakeraw), returns 0 on success <0 on failure
   static bool setup(int mode = NORMAL);
 
   // release vkey resources and restore tty


### PR DESCRIPTION
There seems to be a collision with the name RAW.

Eg: https://buildd.debian.org/status/fetch.php?pkg=ugrep&arch=hurd-i386&ver=2.1.1%2Bdfsg-1&stamp=1594974445&raw=0

g++ -std=gnu++11 -DHAVE_CONFIG_H -I. -I..  -I../include  -msse2 -DHAVE_SSE2  -DPLATFORM=\"i686-unknown-gnu0.9\" -DGREP_PATH=\"/usr/local/share/ugrep/patterns\" -DWITH_NO_INDENT -I/usr/include -I/usr/include -I/usr/include -I/usr/include -I/usr/include -I/usr/include -I/usr/include -I/usr/include -I/usr/include -I/usr/include  -Wall -Wextra -Wunused -O2 -MT ugrep-ugrep.o -MD -MP -MF .deps/ugrep-ugrep.Tpo -c -o ugrep-ugrep.o `test -f 'ugrep.cpp' || echo './'`ugrep.cpp
In file included from /usr/include/i386-gnu/sys/ioctl.h:26,
                 from vkey.hpp:208,
                 from screen.hpp:41,
                 from query.hpp:41,
                 from ugrep.cpp:76:
vkey.hpp:218:20: error: expected unqualified-id before numeric constant
  218 |   static const int RAW      = 1;   // VKey::setup in tty raw mode (cfmakeraw)
      |                    ^~~

Signed-off-by: Ricardo Ribalda <ricardo@ribalda.com>