### PR TITLE
ugrep: Enable color by default in screen/tmux

### DIFF
--- a/src/ugrep.cpp
+++ b/src/ugrep.cpp
@@ -5338,6 +5338,7 @@ void terminal()
           if (term &&
               (strstr(term, "ansi") != NULL ||
                strstr(term, "xterm") != NULL ||
+               strstr(term, "screen") != NULL ||
                strstr(term, "color") != NULL))
             color_term = true;
         }


### PR DESCRIPTION
screen and tmux support colored output and also deserve pretty ugrep
output.

Signed-off-by: Ricardo Ribalda <ricardo@ribalda.com>