### PR TITLE
tests: Move generating input data into a separate script.

### DIFF
--- a/tests/Hello.java
+++ b/tests/Hello.java
@@ -1,5 +1,4 @@
 import java.lang.*;
-
 public class Hello // prints a Hello World! greeting
 { public static void main(String[] arg)
   { System.out.println("Hello World!");

--- a/tests/Hello.ps
+++ b/tests/Hello.ps
@@ -1,0 +1,12 @@
+%!PS-Adobe-2.0
+%%Creator: manual
+%%Title: Hello
+%%EndComments
+/Helvetica findfont 16 scalefont setfont
+80 650 moveto
+(For the tests the PDF is treated as a binary file.) show
+80 630 moveto
+(The title is what is matched, not the contained text.) show
+80 590 moveto
+(Anyhow: Hello, world!) show
+showpage

--- a/tests/gen-test-inputs.sh
+++ b/tests/gen-test-inputs.sh
@@ -40,8 +40,10 @@ for (( i = 0 ; i < 100000 ; i++ )) ; do
 done | gzip -c > archive.gz
 
 
-ls Hello.{bat,class,java,pdf,sh,txt} empty.txt | cpio -o --quiet > archive.cpio
-ls Hello.{bat,class,java,pdf,sh,txt} empty.txt | pax -w -f archive.pax
+ls -f Hello.{bat,class,java,pdf,sh,txt} empty.txt | \
+    cpio -o --quiet > archive.cpio
+ls -f Hello.{bat,class,java,pdf,sh,txt} empty.txt | \
+    pax -w -f archive.pax
 tar cf archive.tar Hello.{bat,class,java,pdf,sh,txt} empty.txt
 compress -c archive.tar > archive.tar.Z
 gzip  -9 -c archive.tar > archive.tgz

--- a/tests/gen-test-inputs.sh
+++ b/tests/gen-test-inputs.sh
@@ -57,6 +57,10 @@ else
     pax="tar -c --files-from=-"
 fi
 
+# For the tests, the archives need not to be deterministic, since
+# user, groups, mtime, mode, etc. are not output by ugrep and are not
+# relevant for the tests.
+
 ls -f Hello.{bat,class,java,pdf,sh,txt} empty.txt | \
     cpio -o --format odc --quiet > archive.cpio
 ls -f Hello.{bat,class,java,pdf,sh,txt} empty.txt | \

--- a/tests/gen-test-inputs.sh
+++ b/tests/gen-test-inputs.sh
@@ -39,11 +39,18 @@ for (( i = 0 ; i < 100000 ; i++ )) ; do
   echo "Lorem ipsum dolor sit amet, consectetur adipiscing elit.  Nunc hendrerit at metus sit amet aliquam."
 done | gzip -c > archive.gz
 
+# pax by default creates tar archives. Thus if pax is not availalbe,
+# just use tar, passing it required options.
+if which pax >/dev/null 2>&1 ; then
+    pax="pax -w"
+else
+    pax="tar -c --files-from=-"
+fi
 
 ls -f Hello.{bat,class,java,pdf,sh,txt} empty.txt | \
     cpio -o --quiet > archive.cpio
 ls -f Hello.{bat,class,java,pdf,sh,txt} empty.txt | \
-    pax -w -f archive.pax
+    $pax -f archive.pax
 tar cf archive.tar Hello.{bat,class,java,pdf,sh,txt} empty.txt
 compress -c archive.tar > archive.tar.Z
 gzip  -9 -c archive.tar > archive.tgz

--- a/tests/gen-test-inputs.sh
+++ b/tests/gen-test-inputs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # requires: tar, compress, pax, cpio, gzip, bzip2, lzma, xz, lz4, zip,
-# iconv
+# iconv, javac
 
 echo "GENERATING SIMPLE FILES"
 
@@ -24,6 +24,10 @@ iconv --from-code latin1 --to-code UTF-16BE >> lorem.utf16.txt lorem.latin1.txt
 # UTF-32 in big-endian including a BOM indicating big-endian
 echo -ne '\x00\x00\xFE\xFF' > lorem.utf32.txt
 iconv --from-code latin1 --to-code UTF-32BE >> lorem.utf32.txt lorem.latin1.txt
+
+
+echo "COMPILING JAVA CODE"
+javac Hello.java
 
 
 

--- a/tests/gen-test-inputs.sh
+++ b/tests/gen-test-inputs.sh
@@ -37,6 +37,8 @@ echo "GENERATING PDF"
 # pdf1.3 for smaller file size (no XML meta-data)
 # printer to include more binary data (font, color profile)
 ps2pdf13 -dPDFSETTINGS=/printer Hello.ps Hello.pdf
+sed -e "s!\(/\(Creation\|Mod\)Date\)([^)]*)!\1(D:19700102030405+00'00')!" \
+    -e "s!\(/Producer\)([^)]*)!\1(Some Producer)!" -i Hello.pdf
 
 
 echo "GENERATING TEST ARCHIVES"

--- a/tests/gen-test-inputs.sh
+++ b/tests/gen-test-inputs.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 # requires: tar, compress, pax, cpio, gzip, bzip2, lzma, xz, lz4, zip
 
+echo "GENERATING SIMPLE FILES"
+
+echo -n > empty.txt
+
+cat > lorem << END
+Lorêm
+ïpsûm
+dolor
+sit
+amét
+END
+
+
 
 echo "GENERATING TEST ARCHIVES"
 

--- a/tests/gen-test-inputs.sh
+++ b/tests/gen-test-inputs.sh
@@ -48,7 +48,7 @@ else
 fi
 
 ls -f Hello.{bat,class,java,pdf,sh,txt} empty.txt | \
-    cpio -o --quiet > archive.cpio
+    cpio -o --format odc --quiet > archive.cpio
 ls -f Hello.{bat,class,java,pdf,sh,txt} empty.txt | \
     $pax -f archive.pax
 tar cf archive.tar Hello.{bat,class,java,pdf,sh,txt} empty.txt

--- a/tests/gen-test-inputs.sh
+++ b/tests/gen-test-inputs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# requires: tar, compress, pax, cpio, gzip, bzip2, lzma, xz, lz4, zip
+
+
+echo "GENERATING TEST ARCHIVES"
+
+rm -f archive.*
+
+for (( i = 0 ; i < 100000 ; i++ )) ; do
+  echo "Lorem ipsum dolor sit amet, consectetur adipiscing elit.  Nunc hendrerit at metus sit amet aliquam."
+done | gzip -c > archive.gz
+
+
+ls Hello.{bat,class,java,pdf,sh,txt} empty.txt | cpio -o --quiet > archive.cpio
+ls Hello.{bat,class,java,pdf,sh,txt} empty.txt | pax -w -f archive.pax
+tar cf archive.tar Hello.{bat,class,java,pdf,sh,txt} empty.txt
+compress -c archive.tar > archive.tar.Z
+gzip  -9 -c archive.tar > archive.tgz
+bzip2 -9 -c archive.tar > archive.tbz
+lzma  -9 -c archive.tar > archive.tlz
+xz    -9 -c archive.tar > archive.txz
+lz4   -9 -c archive.tar > archive.tar.lz4
+zip   -9 -q archive.tar.zip archive.tar
+zip   -9 -q archive.zip Hello.{bat,class,java,pdf,sh,txt} empty.txt

--- a/tests/gen-test-inputs.sh
+++ b/tests/gen-test-inputs.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# requires: tar, compress, pax, cpio, gzip, bzip2, lzma, xz, lz4, zip
+# requires: tar, compress, pax, cpio, gzip, bzip2, lzma, xz, lz4, zip,
+# iconv
 
 echo "GENERATING SIMPLE FILES"
 
@@ -12,6 +13,17 @@ dolor
 sit
 amét
 END
+
+
+echo "GENERATING LOREM FILES"
+
+iconv --from-code latin1 --to-code UTF-8    >  lorem.utf8.txt  lorem.latin1.txt
+# UTF-16 in big-endian including a BOM indicating big-endian
+echo -ne '\xFE\xFF' > lorem.utf16.txt
+iconv --from-code latin1 --to-code UTF-16BE >> lorem.utf16.txt lorem.latin1.txt
+# UTF-32 in big-endian including a BOM indicating big-endian
+echo -ne '\x00\x00\xFE\xFF' > lorem.utf32.txt
+iconv --from-code latin1 --to-code UTF-32BE >> lorem.utf32.txt lorem.latin1.txt
 
 
 

--- a/tests/gen-test-inputs.sh
+++ b/tests/gen-test-inputs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # requires: tar, compress, pax, cpio, gzip, bzip2, lzma, xz, lz4, zip,
-# iconv, javac
+# iconv, javac, ps2pdf
 
 echo "GENERATING SIMPLE FILES"
 
@@ -29,6 +29,14 @@ iconv --from-code latin1 --to-code UTF-32BE >> lorem.utf32.txt lorem.latin1.txt
 echo "COMPILING JAVA CODE"
 javac Hello.java
 
+
+echo "GENERATING PDF"
+# For the tests the PDF is treated as a binary file. The title is what
+# is matched, not the contained text.
+
+# pdf1.3 for smaller file size (no XML meta-data)
+# printer to include more binary data (font, color profile)
+ps2pdf13 -dPDFSETTINGS=/printer Hello.ps Hello.pdf
 
 
 echo "GENERATING TEST ARCHIVES"

--- a/tests/gen.sh
+++ b/tests/gen.sh
@@ -28,12 +28,12 @@ rm -rf out/ dir1/ dir2
 
 mkdir -p out dir1 dir2
 
-cd dir1; ln -s ../Hello.java .; cd ..
-cd dir1; cp ../Hello.sh .; cd ..
-cd dir2; ln -s ../Hello.java .; cd ..
-cd dir2; cp ../Hello.sh .; cd ..
-cd dir1; ln -s ../dir2 .; cd ..
-cd dir2; ln -s ../dir1 .; cd ..
+ln -s ../Hello.java dir1
+cp Hello.sh dir1
+ln -s ../Hello.java dir2
+cp Hello.sh dir2
+ln -s ../dir2 dir1
+ln -s ../dir1 dir2
 cat > dir1/.gitignore << END
 # ignore shells
 *.sh

--- a/tests/gen.sh
+++ b/tests/gen.sh
@@ -57,15 +57,6 @@ $UG -Rl --filter='sh:head -n1'           Hello dir1 > out/dir--filter.out
 
 rm -rf dir1 dir2
 
-echo "GENERATING TEST FILES"
-
-cat > lorem << END
-Lorêm
-ïpsûm
-dolor
-sit
-amét
-END
 
 echo "GENERATING TEST OUTPUT FILES"
 

--- a/tests/gen.sh
+++ b/tests/gen.sh
@@ -67,6 +67,8 @@ sit
 amét
 END
 
+echo "GENERATING TEST OUTPUT FILES"
+
 $UG -Fiwco -f lorem lorem.utf8.txt  > out/lorem.utf8.out
 $UG -Fiwco -f lorem lorem.utf16.txt > out/lorem.utf16.out
 $UG -Fiwco -f lorem lorem.utf32.txt > out/lorem.utf32.out
@@ -74,56 +76,56 @@ cat lorem | $UG -Fiwco --encoding=LATIN1 -f - lorem.latin1.txt > out/lorem.latin
 
 $UG -Zio Lorem lorem.utf8.txt > out/lorem_Lorem-Zio.out
 
-$UG -ci hello Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > out/Hello_Hello-ci.out
-$UG -cj hello Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > out/Hello_Hello-cj.out
+$UG -ci hello Hello.{bat,class,java,pdf,sh,txt} > out/Hello_Hello-ci.out
+$UG -cj hello Hello.{bat,class,java,pdf,sh,txt} > out/Hello_Hello-cj.out
 
-$UG -e Hello -e '".*?"' Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > out/Hello_Hello-ee.out
-$UG -e Hello -N '".*?"' Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > out/Hello_Hello-eN.out
-$UG --max-count=1 Hello Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > out/Hello_Hello--max-count.out
-$UG --max-files=1 Hello Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > out/Hello_Hello--max-files.out
-$UG --range=1,1   Hello Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > out/Hello_Hello--range.out
+$UG -e Hello -e '".*?"' Hello.{bat,class,java,pdf,sh,txt} > out/Hello_Hello-ee.out
+$UG -e Hello -N '".*?"' Hello.{bat,class,java,pdf,sh,txt} > out/Hello_Hello-eN.out
+$UG --max-count=1 Hello Hello.{bat,class,java,pdf,sh,txt} > out/Hello_Hello--max-count.out
+$UG --max-files=1 Hello Hello.{bat,class,java,pdf,sh,txt} > out/Hello_Hello--max-files.out
+$UG --range=1,1   Hello Hello.{bat,class,java,pdf,sh,txt} > out/Hello_Hello--range.out
 
 for PAT in '' 'Hello' '\w+\s+\S+' '\S\n\S' 'nomatch' ; do
   FN=`echo "Hello_$PAT" | tr -Cd '[:alnum:]_'`
   for OUT in '' '-I' '-W' '-X' ; do
     for OPS in '' '-l' '-lv' '-c' '-co' '-cv' '-n' '-nkbT' '-unkbT' '-o' '-on' '-onkbT' '-ounkbT' '-v' '-nv' '-C2' '-nC2' '-vC2' '-nvC2' '-y' '-ny' '-vy' '-nvy' ; do
-      $UG -U $OUT $OPS "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN$OUT$OPS.out"
+      $UG -U $OUT $OPS "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN$OUT$OPS.out"
     done
   done
   for OUT in '--csv' '--json' '--xml' ; do
     for OPS in '' '-l' '-lv' '-c' '-co' '-cv' '-n' '-v' '-nv' '-nkb' '-unkb' '-o' '-on' '-onkb' '-ounkb' ; do
-      $UG -U $OUT $OPS "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN$OUT$OPS.out"
+      $UG -U $OUT $OPS "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN$OUT$OPS.out"
     done
   done
-  $UG -U --format-open='%m) %f:%~' --format='  %m) %n,%k %w-%d%~' --format-close='%~' "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN--format.out"
-  $UG -U -v --format-open='%m) %f:%~' --format='  %m) %n,%k %w-%d%~' --format-close='%~' "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN-v--format.out"
-  $UG -U -Iw "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN-Iw.out"
-  $UG -U -Ix "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN-Ix.out"
-  $UG -U -F  "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN-F.out"
-  $UG -U -Fw "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN-Fw.out"
-  $UG -U -Fx "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN-Fx.out"
+  $UG -U --format-open='%m) %f:%~' --format='  %m) %n,%k %w-%d%~' --format-close='%~' "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN--format.out"
+  $UG -U -v --format-open='%m) %f:%~' --format='  %m) %n,%k %w-%d%~' --format-close='%~' "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN-v--format.out"
+  $UG -U -Iw "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN-Iw.out"
+  $UG -U -Ix "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN-Ix.out"
+  $UG -U -F  "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN-F.out"
+  $UG -U -Fw "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN-Fw.out"
+  $UG -U -Fx "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN-Fx.out"
   if [ "$PAT" == '\w+\s+\S+' ]; then
-    $UG -U -G  '\w\+\s\+\S\+' Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN-G.out"
-    $UG -U -Gw '\w\+\s\+\S\+' Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN-Gw.out"
-    $UG -U -Gx '\w\+\s\+\S\+' Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN-Gx.out"
+    $UG -U -G  '\w\+\s\+\S\+' Hello.{bat,class,java,pdf,sh,txt} > "out/$FN-G.out"
+    $UG -U -Gw '\w\+\s\+\S\+' Hello.{bat,class,java,pdf,sh,txt} > "out/$FN-Gw.out"
+    $UG -U -Gx '\w\+\s\+\S\+' Hello.{bat,class,java,pdf,sh,txt} > "out/$FN-Gx.out"
   else
-    $UG -U -G  "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN-G.out"
-    $UG -U -Gw "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN-Gw.out"
-    $UG -U -Gx "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN-Gx.out"
+    $UG -U -G  "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN-G.out"
+    $UG -U -Gw "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN-Gw.out"
+    $UG -U -Gx "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN-Gx.out"
   fi
-  $UG -U -IP  "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN-IP.out"
-  $UG -U -IPw "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN-IPw.out"
-  $UG -U -IPx "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN-IPx.out"
+  $UG -U -IP  "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN-IP.out"
+  $UG -U -IPw "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN-IPw.out"
+  $UG -U -IPx "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN-IPx.out"
 done
 
 for PAT in '' 'Hello World' 'Hello -World' 'Hello -World|greeting' 'Hello -(greeting|World)' '"a Hello" greeting' ; do
   FN=`echo "Hello_$PAT" | tr -Cd '[:alnum:]_-'`
-  $UG -U --bool "$PAT" Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/$FN--bool.out"
+  $UG -U --bool "$PAT" Hello.{bat,class,java,pdf,sh,txt} > "out/$FN--bool.out"
 done
 
-$UG -U -e 'Hello' --and 'World' Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/Hello--and.out"
-$UG -U -e 'Hello' --andnot 'World' Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/Hello--andnot.out"
-$UG -U -e 'Hello' --and --not 'World' -e 'greeting' Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/Hello--and--not.out"
+$UG -U -e 'Hello' --and 'World' Hello.{bat,class,java,pdf,sh,txt} > "out/Hello--and.out"
+$UG -U -e 'Hello' --andnot 'World' Hello.{bat,class,java,pdf,sh,txt} > "out/Hello--andnot.out"
+$UG -U -e 'Hello' --and --not 'World' -e 'greeting' Hello.{bat,class,java,pdf,sh,txt} > "out/Hello--and--not.out"
 
 $UG -z -c Hello archive.cpio    > out/archive.cpio.out
 $UG -z -c Hello archive.pax     > out/archive.pax.out

--- a/tests/gen.sh
+++ b/tests/gen.sh
@@ -20,6 +20,8 @@ esac
 
 export GREP_COLORS='cx=hb:ms=hug:mc=ib+W:fn=h35:ln=32h:cn=1;32:bn=1;32:se=+36'
 
+sh "./gen-test-inputs.sh"
+
 echo "GENERATING TEST DIRECTORIES"
 
 rm -rf out/ dir1/ dir2
@@ -123,22 +125,6 @@ $UG -U -e 'Hello' --and 'World' Hello.bat Hello.class Hello.java Hello.pdf Hello
 $UG -U -e 'Hello' --andnot 'World' Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/Hello--andnot.out"
 $UG -U -e 'Hello' --and --not 'World' -e 'greeting' Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt > "out/Hello--and--not.out"
 
-echo "GENERATING TEST ARCHIVES"
-
-rm -f archive.*
-
-ls Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt empty.txt | cpio -o --quiet > archive.cpio
-ls Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt empty.txt | pax -w -f archive.pax
-tar cf archive.tar Hello.* empty.txt
-compress -c archive.tar > archive.tar.Z
-gzip  -9 -c archive.tar > archive.tgz
-bzip2 -9 -c archive.tar > archive.tbz
-lzma  -9 -c archive.tar > archive.tlz
-xz    -9 -c archive.tar > archive.txz
-lz4   -9 -c archive.tar > archive.tar.lz4
-zip   -9 -q archive.tar.zip archive.tar
-zip   -9 -q archive.zip Hello.bat Hello.class Hello.java Hello.pdf Hello.sh Hello.txt empty.txt
-
 $UG -z -c Hello archive.cpio    > out/archive.cpio.out
 $UG -z -c Hello archive.pax     > out/archive.pax.out
 $UG -z -c Hello archive.tar     > out/archive.tar.out
@@ -162,10 +148,6 @@ $UG -z -c -tShell Hello archive.tbz     > out/archive-t.tbz.out
 $UG -z -c -tShell Hello archive.tlz     > out/archive-t.tlz.out
 $UG -z -c -tShell Hello archive.txz     > out/archive-t.txz.out
 $UG -z -c -tShell Hello archive.tar.lz4 > out/archive-t.tar.lz4.out
-
-for (( i = 0 ; i < 100000 ; i++ )) ; do
-  echo "Lorem ipsum dolor sit amet, consectetur adipiscing elit.  Nunc hendrerit at metus sit amet aliquam."
-done | gzip -c > archive.gz
 
 $UG -z -c '' archive.gz > out/archive.gz.out
 


### PR DESCRIPTION
Some Linux distributions are eager to build everything from source,
including test-files. Moving the generation of the inout data into a
script separate from generating the expected results makes live much
easier for the maintainers of ugrep in these distributions.