### PR TITLE
mmap.hpp: Add missing header file

### DIFF
--- a/src/mmap.hpp
+++ b/src/mmap.hpp
@@ -37,6 +37,7 @@
 #ifndef MMAP_HPP
 #define MMAP_HPP
 
+#include <limits>
 #include "ugrep.hpp"
 
 // --min-mmap and --max-mmap file size to allocate with mmap(), not greater than 4294967295LL, 0 disables mmap()


### PR DESCRIPTION
gcc-11 Fails to build wit this error:

mmap.hpp: In member function ‘bool MMap::file(reflex::Input&, const char*&, size_t&)’:
mmap.hpp:90:176: error: ‘numeric_limits’ is not a member of ‘std’

Complete log:
https://people.debian.org/~doko/logs/20210228/filtered/gcc11/ugrep_3.1.9+dfsg-1_unstable_gcc11.log

Signed-off-by: Ricardo Ribalda <ricardo@ribalda.com>