### PR TITLE
Use option `-U` instead of `-C` for `diff`

### DIFF
--- a/tests/verify.sh
+++ b/tests/verify.sh
@@ -74,7 +74,7 @@ function ERR() {
   exit 1
 }
 
-DIFF="diff -C1 -"
+DIFF="diff -U1 -"
 
 rm -rf dir1/ dir2/
 


### PR DESCRIPTION
`verify.sh` fails on distributions using the BusyBox version of the diff utility, such as Alpine.
This version of diff does not offer the `-C` option, but `-U` gives similar output.
https://www.busybox.net/downloads/BusyBox.html