### PR TITLE
Python3 files are not found using -M option (#163)

### DIFF
--- a/src/ugrep.cpp
+++ b/src/ugrep.cpp
@@ -3447,7 +3447,7 @@ const Type type_table[] = {
   { "Png",          "png", NULL,                                                      "\\x89png\\x0d\\x0a\\x1a\\x0a" },
   { "prolog",       "pl,pro", NULL,                                                   NULL },
   { "python",       "py", NULL,                                                       NULL },
-  { "Python",       "py", NULL,                                                       "#!\\h*/.*\\Wpython(\\W.*)?\\n" },
+  { "Python",       "py", NULL,                                                       "#!\\h*/.*\\Wpython[23]?(\\W.*)?\\n" },
   { "r",            "R", NULL,                                                        NULL },
   { "rpm",          "rpm", NULL,                                                      NULL },
   { "Rpm",          "rpm", NULL,                                                      "\\xed\\xab\\xee\\xdb" },


### PR DESCRIPTION
Relax the regular expressions a bit, allowing files with explicit
version to be found.