### PR TITLE
ugrep - normalize CRLF output

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ search for "Path" in *Find a Setting*.  Select *environment variables* ->
 `ug.exe` executables.
 
 Notes on using `ugrep.exe` and `ug.exe` from the Windows command line:
-- file and directory globs should be specified with option `-g/GLOB` instead
-  of a `GLOB` command line argument (globbing is disabled, because `*` and `?`
-  in patterns would get replaced).
+- file and directory globs specified with option `-g/GLOB` may behave more
+  intuitively than a `GLOB` command line argument, especially when directory
+  recursion is enabled.
 - when quoting patterns and arguments on the command line, do not use single
   `'` quotes but use `"` instead; most Windows command utilities consider
   the single `'` quotes part of the command-line argument!

--- a/include/reflex/input.h
+++ b/include/reflex/input.h
@@ -450,7 +450,7 @@ class Input {
       istream_(NULL),
       size_(0)
   {
-    init(enc);
+    init();
     if (file_encoding() == file_encoding::plain)
       file_encoding(enc, page);
   }
@@ -731,7 +731,7 @@ class Input {
     return utfx_;
   }
   /// Initialize the state after (re)setting the input source, auto-detects UTF BOM in FILE* input if the file size is known.
-  void init(file_encoding_type enc = file_encoding::plain)
+  void init()
   {
     std::memset(utf8_, 0, sizeof(utf8_));
     uidx_ = 0;
@@ -740,10 +740,10 @@ class Input {
     page_ = NULL;
     handler_ = NULL;
     if (file_ != NULL)
-      file_init(enc);
+      file_init();
   }
   /// Called by init() for a FILE*.
-  void file_init(file_encoding_type enc);
+  void file_init();
   /// Called by size() for a wstring.
   void wstring_size();
   /// Called by size() for a FILE*.

--- a/lib/input.cpp
+++ b/lib/input.cpp
@@ -651,12 +651,8 @@ const unsigned short codepages[38][256] =
   },
 };
 
-void Input::file_init(file_encoding_type enc)
+void Input::file_init()
 {
-  // open in binary mode to detect BOM, then reset to original mode afterwards unless UTF-16 or UTF-32
-#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
-  int mode = _setmode(_fileno(file_), _O_BINARY);
-#endif
   // attempt to determine the file size with fstat()
 #if !defined(HAVE_CONFIG_H) || defined(HAVE_FSTAT)
 #if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
@@ -756,13 +752,6 @@ void Input::file_init(file_encoding_type enc)
     if (handler_ == NULL || feof(file_) || (*handler_)() == 0)
       break;
   }
-#if (defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(__BORLANDC__)) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
-  // if not UTF-16 or UTF-32, then reset mode to original mode (unless the original mode was binary)
-  if (mode != _O_BINARY && ((utfx_ == file_encoding::plain && enc != file_encoding::utf16be && enc != file_encoding::utf16le && enc != file_encoding::utf32be && enc != file_encoding::utf32le) || utfx_ == file_encoding::utf8))
-    _setmode(_fileno(file_), mode);
-#else
-  UNUSED(enc);
-#endif
 }
 
 size_t Input::file_get(char *s, size_t n)

--- a/src/cnf.cpp
+++ b/src/cnf.cpp
@@ -35,6 +35,7 @@
 */
 
 #include "cnf.hpp"
+#include "ugrep.hpp" // NEWLINESTR
 
 // parse a pattern into an operator tree using a recursive descent parser
 void CNF::OpTree::parse(const char *& pattern)
@@ -597,9 +598,9 @@ void CNF::report(FILE *output) const
     return;
 
   if (flag_fuzzy > 0)
-    fprintf(output, "Lines fuzzy-matched with max edit distance %zu if:\n  ", flag_fuzzy & 255);
+    fprintf(output, "Lines fuzzy-matched with max edit distance %zu if:" NEWLINESTR "  ", flag_fuzzy & 255);
   else
-    fprintf(output, "Lines matched if:\n  ");
+    fprintf(output, "Lines matched if:" NEWLINESTR "  ");
 
   if (!flag_file.empty())
   {
@@ -621,7 +622,7 @@ void CNF::report(FILE *output) const
 
     // if the first CNF term is left empty then we match -f FILE with additional constraints, i.e. not as an alternation
     if (terms.front().empty())
-      fprintf(output, ", and\n  ");
+      fprintf(output, ", and" NEWLINESTR "  ");
     else
       fprintf(output, " or ");
   }
@@ -631,7 +632,7 @@ void CNF::report(FILE *output) const
   for (auto i = terms.begin(); i != terms.end(); ++i)
   {
     if (and_sep)
-      fprintf(output, ", and\n  ");
+      fprintf(output, ", and" NEWLINESTR "  ");
 
     bool or_sep = false;
 
@@ -656,7 +657,7 @@ void CNF::report(FILE *output) const
     }
   }
 
-  fprintf(output, "\n");
+  fprintf(output, NEWLINESTR);
 }
 
 // return all OR-terms of the CNF joined together

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -211,6 +211,20 @@ void Output::Dump::line()
   pstar = false;
 }
 
+void Output::nl_or_lf(bool
+#ifdef OS_WIN
+    lf_only // Parameter only used for Windows "\r\n" newline.
+#endif
+    )
+{
+#ifdef OS_WIN
+    if (!lf_only)
+      chr('\r');
+#endif
+    chr('\n');
+    check_flush();
+}
+
 // output the header part of the match, preceding the matched line
 void Output::header(const char *& pathname, const std::string& partname, size_t lineno, reflex::AbstractMatcher *matcher, size_t byte_offset, const char *separator, bool newline)
 {
@@ -265,7 +279,7 @@ void Output::header(const char *& pathname, const std::string& partname, size_t 
       str(color_fn);
       str(color_del);
       str(color_off);
-      chr('\n');
+      nl_no_flush();
       pathname = NULL;
     }
     else

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -553,12 +553,16 @@ class Output {
         // if multi-threaded and lock is not owned already, then lock on master's mutex
         acquire();
 
+        bool block_ended_with_cr = false;
+
         // flush the buffers container to the designated output file, pipe, or stream
         for (Buffers::iterator i = buffers_.begin(); i != buf_; ++i)
         {
-          size_t nwritten = fwrite(i->data, 1, SIZE, file);
+          size_t num = normalize_crlf(i->data, SIZE, &block_ended_with_cr);
 
-          if (nwritten < SIZE)
+          size_t nwritten = fwrite(i->data, 1, num, file);
+
+          if (nwritten < num)
           {
             cancel();
             break;
@@ -571,10 +575,15 @@ class Output {
 
           if (num > 0)
           {
-            size_t nwritten = fwrite(buf_->data, 1, num, file);
+            num = normalize_crlf(buf_->data, num, &block_ended_with_cr);
 
-            if (nwritten < num)
-              cancel();
+            if (num > 0)
+            {
+              size_t nwritten = fwrite(buf_->data, 1, num, file);
+
+              if (nwritten < num)
+                cancel();
+            }
           }
 
           if (!eof && fflush(file) != 0)
@@ -669,6 +678,46 @@ class Output {
   {
     buf_ = buffers_.emplace(buffers_.end());
     cur_ = buf_->data;
+  }
+
+  // In-place conversion of "\r\n", "\r", and "\n" to "\n".
+  // Returns the updated buffer size.
+  static size_t normalize_crlf(char* data, size_t data_len, bool* block_ended_with_cr)
+  {
+    size_t input_pos = 0;
+    size_t output_pos = 0;
+
+    // If the previous normalize_crlf ended on a '\r' then we should skip a leading '\n'.
+    if (*block_ended_with_cr && data[0] == '\n')
+      input_pos += 1;
+
+    *block_ended_with_cr = false;
+
+    for (; input_pos != data_len; input_pos += 1)
+    {
+      char c = data[input_pos];
+
+      // Special treatment needed only for '\r'.
+      if (c == '\r')
+      {
+        if (input_pos + 1 == data_len)
+        {
+          // '\r' at end of block: convert to '\n' and carry over to next block.
+          *block_ended_with_cr = true;
+        }
+        else if (data[input_pos + 1] == '\n')
+        {
+          // "\r\n": convert to '\n'.
+          input_pos += 1;
+        }
+
+        c = '\n';
+      }
+
+      data[output_pos++] = c;
+    }
+
+    return output_pos;
   }
 
   // get a group capture's string pointer and size specified by %[ARG] as arg, if any

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -569,19 +569,14 @@ class Output {
 
         if (!eof)
         {
-          size_t num = cur_ - buf_->data;
+          size_t num = remove_cr(buf_->data, cur_ - buf_->data);
 
           if (num > 0)
           {
-            num = remove_cr(buf_->data, num);
+            size_t nwritten = fwrite(buf_->data, 1, num, file);
 
-            if (num > 0)
-            {
-              size_t nwritten = fwrite(buf_->data, 1, num, file);
-
-              if (nwritten < num)
-                cancel();
-            }
+            if (nwritten < num)
+              cancel();
           }
 
           if (!eof && fflush(file) != 0)
@@ -682,15 +677,40 @@ class Output {
   // Returns the updated buffer size.
   static size_t remove_cr(char* data, size_t data_len)
   {
-    size_t output_pos = 0;
-    for (size_t input_pos = 0; input_pos != data_len; input_pos += 1)
+    size_t output_len;
+
+    // First iteration unrolled because first iteration's memmove is a no-op.
+    char* cr_pos = (char*)memchr(data, '\r', data_len);
+    if (!cr_pos)
     {
-      char c = data[input_pos];
-      data[output_pos] = c;
-      output_pos += (c != '\r');
+      // If there are no CR bytes in the data, the entire operation is a no-op.
+      output_len = data_len;
+    }
+    else
+    {
+      char* output_pos = cr_pos;
+
+      char* const data_end = data + data_len;
+      for (char* input_pos = cr_pos + 1; data_end - input_pos != 0; input_pos = cr_pos + 1)
+      {
+        cr_pos = (char*)memchr(input_pos, '\r', data_end - input_pos);
+        if (!cr_pos)
+        {
+          size_t const chunk_len = data_end - input_pos;
+          memmove(output_pos, input_pos, chunk_len);
+          output_pos += chunk_len;
+          break;
+        }
+
+        size_t const chunk_len = cr_pos - input_pos;
+        memmove(output_pos, input_pos, chunk_len);
+        output_pos += chunk_len;
+      }
+
+      output_len = output_pos - data;
     }
 
-    return output_pos;
+    return output_len;
   }
 
   // get a group capture's string pointer and size specified by %[ARG] as arg, if any

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -3432,7 +3432,7 @@ void Query::set_stdin()
       return;
     }
 
-    source = fdopen(stdin_pipe_[0], "r");
+    source = fdopen(stdin_pipe_[0], "rb");
 
     stdin_thread_ = std::thread(Query::stdin_sender, stdin_pipe_[1]);
   }

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -1647,7 +1647,7 @@ void Query::fetch_all()
 // execute the search in a new thread
 void Query::execute(int fd)
 {
-  output = fdopen(fd, "w");
+  output = fdopen(fd, "wb");
 
   if (output != NULL)
   {

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -54,55 +54,55 @@ void Stats::report(FILE *output)
     fprintf(output, " in %zu director%s", sd, (sd == 1 ? "y" : "ies"));
   fprintf(output, ": %zu matching", ff);
   if (fp > ff)
-    fprintf(output, " + %zu in archives\n", fp - ff);
+    fprintf(output, " + %zu in archives" NEWLINESTR, fp - ff);
   else
-    fprintf(output, "\n");
+    fprintf(output, NEWLINESTR);
   if (warnings > 0)
-    fprintf(output, "Received %zu warning%s\n", ws, ws == 1 ? "" : "s");
+    fprintf(output, "Received %zu warning%s" NEWLINESTR, ws, ws == 1 ? "" : "s");
 
-  fprintf(output, "The following pathname selections and restrictions were applied:\n");
+  fprintf(output, "The following pathname selections and restrictions were applied:" NEWLINESTR);
   if (flag_config != NULL)
-    fprintf(output, "  --config=%s\n", flag_config_file.c_str());
+    fprintf(output, "  --config=%s" NEWLINESTR, flag_config_file.c_str());
 #ifdef WITH_HIDDEN
   if (flag_hidden)
-    fprintf(output, "  --hidden (default)\n");
+    fprintf(output, "  --hidden (default)" NEWLINESTR);
   else
-    fprintf(output, "  --no-hidden\n");
+    fprintf(output, "  --no-hidden" NEWLINESTR);
 #else
   if (flag_hidden)
-    fprintf(output, "  --hidden\n");
+    fprintf(output, "  --hidden" NEWLINESTR);
   else
-    fprintf(output, "  --no-hidden (default)\n");
+    fprintf(output, "  --no-hidden (default)" NEWLINESTR);
 #endif
   if (flag_min_depth > 0 && flag_max_depth > 0)
-    fprintf(output, "  --depth=%zu,%zu\n", flag_min_depth, flag_max_depth);
+    fprintf(output, "  --depth=%zu,%zu" NEWLINESTR, flag_min_depth, flag_max_depth);
   else if (flag_min_depth > 0)
-    fprintf(output, "  --depth=%zu,\n", flag_min_depth);
+    fprintf(output, "  --depth=%zu," NEWLINESTR, flag_min_depth);
   else if (flag_max_depth > 0)
-    fprintf(output, "  --depth=%zu\n", flag_max_depth);
+    fprintf(output, "  --depth=%zu" NEWLINESTR, flag_max_depth);
   for (auto& i : flag_ignore_files)
-    fprintf(output, "  --ignore-files='%s'\n", i.c_str());
+    fprintf(output, "  --ignore-files='%s'" NEWLINESTR, i.c_str());
   for (auto& i : ignore)
-    fprintf(output, "    %s exclusions were applied to %s\n", i.c_str(), i.substr(0, i.find_last_of(PATHSEPCHR)).c_str());
+    fprintf(output, "    %s exclusions were applied to %s" NEWLINESTR, i.c_str(), i.substr(0, i.find_last_of(PATHSEPCHR)).c_str());
   for (auto& i : flag_file_magic)
   {
     if (!i.empty() && (i.front() == '!' || i.front() == '^'))
-      fprintf(output, "  --file-magic='!%s' (negation)\n", i.c_str() + 1);
+      fprintf(output, "  --file-magic='!%s' (negation)" NEWLINESTR, i.c_str() + 1);
     else
-      fprintf(output, "  --file-magic='%s'\n", i.c_str());
+      fprintf(output, "  --file-magic='%s'" NEWLINESTR, i.c_str());
   }
   for (auto& i : flag_include_fs)
-    fprintf(output, "  --include-fs='%s'\n", i.c_str());
+    fprintf(output, "  --include-fs='%s'" NEWLINESTR, i.c_str());
   for (auto& i : flag_exclude_fs)
-    fprintf(output, "  --exclude-fs='%s'\n", i.c_str());
+    fprintf(output, "  --exclude-fs='%s'" NEWLINESTR, i.c_str());
   for (auto& i : flag_all_include)
-    fprintf(output, "  --include='%s'%s\n", i.c_str(), i.front() == '!' ? " (negated)" : "");
+    fprintf(output, "  --include='%s'%s" NEWLINESTR, i.c_str(), i.front() == '!' ? " (negated)" : "");
   for (auto& i : flag_all_exclude)
-    fprintf(output, "  --exclude='%s'%s\n", i.c_str(), i.front() == '!' ? " (negated)" : "");
+    fprintf(output, "  --exclude='%s'%s" NEWLINESTR, i.c_str(), i.front() == '!' ? " (negated)" : "");
   for (auto& i : flag_all_include_dir)
-    fprintf(output, "  --include-dir='%s'%s\n", i.c_str(), i.front() == '!' ? " (negated)" : "");
+    fprintf(output, "  --include-dir='%s'%s" NEWLINESTR, i.c_str(), i.front() == '!' ? " (negated)" : "");
   for (auto& i : flag_all_exclude_dir)
-    fprintf(output, "  --exclude-dir='%s'%s\n", i.c_str(), i.front() == '!' ? " (negated)" : "");
+    fprintf(output, "  --exclude-dir='%s'%s" NEWLINESTR, i.c_str(), i.front() == '!' ? " (negated)" : "");
 }
 
 size_t                   Stats::files  = 0;

--- a/src/ugrep.cpp
+++ b/src/ugrep.cpp
@@ -1749,11 +1749,10 @@ struct Grep {
       file = source;
 
 #ifdef OS_WIN
-      if (flag_binary || flag_decompress)
-        _setmode(fileno(source), _O_BINARY);
+      _setmode(fileno(source), _O_BINARY);
 #endif
     }
-    else if (fopenw_s(&file, pathname, (flag_binary || flag_decompress ? "rb" : "r")) != 0)
+    else if (fopenw_s(&file, pathname, "rb") != 0)
     {
       warning("cannot read", pathname);
 
@@ -1775,7 +1774,7 @@ struct Grep {
       FILE *pipe_in = NULL;
 
       // open pipe between worker and decompression thread, then start decompression thread
-      if (pipe(pipe_fd) == 0 && (pipe_in = fdopen(pipe_fd[0], "r")) != NULL)
+      if (pipe(pipe_fd) == 0 && (pipe_in = fdopen(pipe_fd[0], "rb")) != NULL)
       {
         // create or open a new zstreambuf to (re)start the decompression thread
         if (zstream == NULL)
@@ -2773,7 +2772,7 @@ struct Grep {
           FILE *pipe_in = NULL;
 
           // open pipe between worker and decompression thread, then start decompression thread
-          if (pipe(pipe_fd) == 0 && (pipe_in = fdopen(pipe_fd[0], "r")) != NULL)
+          if (pipe(pipe_fd) == 0 && (pipe_in = fdopen(pipe_fd[0], "rb")) != NULL)
           {
             // notify the decompression filter thread of the new pipe
             pipe_ready.notify_one();
@@ -6932,7 +6931,7 @@ Grep::Type Grep::select(size_t level, const char *pathname, const char *basename
     {
       FILE *file;
 
-      if (fopenw_s(&file, pathname, (flag_binary || flag_decompress ? "rb" : "r")) != 0)
+      if (fopenw_s(&file, pathname, "rb") != 0)
       {
         warning("cannot read", pathname);
         return Type::SKIP;
@@ -7120,7 +7119,7 @@ Grep::Type Grep::select(size_t level, const char *pathname, const char *basename
           {
             FILE *file;
 
-            if (fopenw_s(&file, pathname, (flag_binary || flag_decompress ? "rb" : "r")) != 0)
+            if (fopenw_s(&file, pathname, "rb") != 0)
             {
               warning("cannot read", pathname);
               return Type::SKIP;
@@ -10889,23 +10888,11 @@ void help(std::ostream& out)
     --tag[=TAG[,END]]\n\
             Disables colors to mark up matches with TAG.  END marks the end of\n\
             a match if specified, otherwise TAG.  The default is `___'.\n\
-    -U, --binary\n"
-#ifdef OS_WIN
-            "\
-            Opens files in binary mode (mode specific to Windows) and disables\n\
-            Unicode matching for binary file matching, forcing PATTERN to match\n\
-            bytes, not Unicode characters.  For example, -U '\\xa3' matches\n\
-            byte A3 (hex) instead of the Unicode code point U+00A3 represented\n\
-            by the UTF-8 sequence C2 A3.  Binary files may appear truncated\n\
-            when searched without this option.  See also option --dotall.\n"
-#else
-            "\
+    -U, --binary\n\
             Disables Unicode matching for binary file matching, forcing PATTERN\n\
             to match bytes, not Unicode characters.  For example, -U '\\xa3'\n\
             matches byte A3 (hex) instead of the Unicode code point U+00A3\n\
-            represented by the UTF-8 sequence C2 A3.  See also option --dotall.\n"
-#endif
-            "\
+            represented by the UTF-8 sequence C2 A3.  See also option --dotall.\n\
     -u, --ungroup\n\
             Do not group multiple pattern matches on the same matched line.\n\
             Output the matched line again for each additional pattern match,\n\

--- a/src/ugrep.cpp
+++ b/src/ugrep.cpp
@@ -909,9 +909,11 @@ struct Grep {
         }
         else
         {
+          bool lf_only = false;
           if (size > 0)
           {
-            size_t sizen = size - (ptr[size - 1] == '\n');
+            lf_only = ptr[size - 1] == '\n';
+            size_t sizen = size - lf_only;
             if (sizen > 0)
             {
               grep.out.str(color_sl);
@@ -920,7 +922,7 @@ struct Grep {
             }
           }
 
-          grep.out.nl();
+          grep.out.nl_or_lf(lf_only);
         }
 
         next_before(buf, len, num, ptr, size, offset);
@@ -1017,9 +1019,11 @@ struct Grep {
         }
         else
         {
+          bool lf_only = false;
           if (rest_line_size > 0)
           {
-            rest_line_size -= rest_line_data[rest_line_size - 1] == '\n';
+            lf_only = rest_line_data[rest_line_size - 1] == '\n';
+            rest_line_size -= lf_only;
             if (rest_line_size > 0)
             {
               grep.out.str(flag_invert_match ? color_cx : color_sl);
@@ -1027,7 +1031,8 @@ struct Grep {
               grep.out.str(color_off);
             }
           }
-          grep.out.nl();
+
+          grep.out.nl_or_lf(lf_only);
         }
 
         rest_line_data = NULL;
@@ -1087,9 +1092,11 @@ struct Grep {
         }
         else
         {
+          bool lf_only = false;
           if (size > 0)
           {
-            size_t sizen = size - (ptr[size - 1] == '\n');
+            lf_only = ptr[size - 1] == '\n';
+            size_t sizen = size - lf_only;
             if (sizen > 0)
             {
               grep.out.str(v_color_cx);
@@ -1098,7 +1105,7 @@ struct Grep {
             }
           }
 
-          grep.out.nl();
+          grep.out.nl_or_lf(lf_only);
         }
 
         next_before(buf, len, num, ptr, size, offset);
@@ -1189,9 +1196,11 @@ struct Grep {
           }
           else
           {
+            bool lf_only = false;
             if (size > 0)
             {
-              size -= ptr[size - 1] == '\n';
+              lf_only = ptr[size - 1] == '\n';
+              size -= lf_only;
               if (size > 0)
               {
                 grep.out.str(color_cx);
@@ -1200,7 +1209,7 @@ struct Grep {
               }
             }
 
-            grep.out.nl();
+            grep.out.nl_or_lf(lf_only);
           }
         }
       }
@@ -1236,9 +1245,11 @@ struct Grep {
         }
         else
         {
+          bool lf_only = false;
           if (rest_line_size > 0)
           {
-            rest_line_size -= rest_line_data[rest_line_size - 1] == '\n';
+            lf_only = rest_line_data[rest_line_size - 1] == '\n';
+            rest_line_size -= lf_only;
             if (rest_line_size > 0)
             {
               grep.out.str(flag_invert_match ? color_cx : color_sl);
@@ -1247,7 +1258,7 @@ struct Grep {
             }
           }
 
-          grep.out.nl();
+          grep.out.nl_or_lf(lf_only);
         }
 
         rest_line_data = NULL;
@@ -1306,9 +1317,11 @@ struct Grep {
           }
           else
           {
+            bool lf_only = false;
             if (size > 0)
             {
-              size_t sizen = size - (ptr[size - 1] == '\n');
+              lf_only = ptr[size - 1] == '\n';
+              size_t sizen = size - lf_only;
               if (sizen > 0)
               {
                 grep.out.str(color_cx);
@@ -1317,7 +1330,7 @@ struct Grep {
               }
             }
 
-            grep.out.nl();
+            grep.out.nl_or_lf(lf_only);
           }
         }
         else if (flag_before_context > 0)
@@ -1470,9 +1483,11 @@ struct Grep {
           }
           else
           {
+            bool lf_only = false;
             if (size > pos)
             {
-              size -= ptr[size - 1] == '\n';
+              lf_only = ptr[size - 1] == '\n';
+              size -= lf_only;
               if (size > pos)
               {
                 grep.out.str(color_cx);
@@ -1481,7 +1496,7 @@ struct Grep {
               }
             }
 
-            grep.out.nl();
+            grep.out.nl_or_lf(lf_only);
           }
         }
       }
@@ -1541,9 +1556,11 @@ struct Grep {
         }
         else
         {
+          bool lf_only = false;
           if (rest_line_size > 0)
           {
-            rest_line_size -= rest_line_data[rest_line_size - 1] == '\n';
+            lf_only = rest_line_data[rest_line_size - 1] == '\n';
+            rest_line_size -= lf_only;
             if (rest_line_size > 0)
             {
               grep.out.str(color_cx);
@@ -1552,7 +1569,7 @@ struct Grep {
             }
           }
 
-          grep.out.nl();
+          grep.out.nl_or_lf(lf_only);
         }
 
         rest_line_data = NULL;
@@ -1611,9 +1628,11 @@ struct Grep {
         }
         else
         {
+          bool lf_only = false;
           if (size > 0)
           {
-            size_t sizen = size - (ptr[size - 1] == '\n');
+            lf_only = ptr[size - 1] == '\n';
+            size_t sizen = size - lf_only;
             if (sizen > 0)
             {
               grep.out.str(color_sl);
@@ -1622,7 +1641,7 @@ struct Grep {
             }
           }
 
-          grep.out.nl();
+          grep.out.nl_or_lf(lf_only);
         }
 
         next_before(buf, len, num, ptr, size, offset);
@@ -5019,6 +5038,12 @@ void init(int argc, const char **argv)
     exit(EXIT_ERROR);
   }
 
+#ifdef OS_WIN
+  // save_config() and help() assume text mode, so switch to
+  // binary after we're no longer going to call them.
+  (void)_setmode(fileno(stdout), _O_BINARY);
+#endif
+
   // --encoding: parse ENCODING value
   if (flag_encoding != NULL)
   {
@@ -5704,7 +5729,7 @@ void terminal()
         // --pager: if output is to a TTY then page through the results
 
         // open a pipe to a forked pager
-        output = popen(flag_pager, "w");
+        output = popen(flag_pager, "wb");
         if (output == NULL)
           error("cannot open pipe to pager", flag_pager);
 
@@ -6710,7 +6735,7 @@ void ugrep()
     bcnf.report(output);
 
     if (strcmp(flag_stats, "vm") == 0 && words > 0)
-      fprintf(output, "VM memory: %zu nodes (%zums), %zu edges (%zums), %zu opcode words (%zums)\n", nodes, nodes_time, edges, edges_time, words, words_time);
+      fprintf(output, "VM memory: %zu nodes (%zums), %zu edges (%zums), %zu opcode words (%zums)" NEWLINESTR, nodes, nodes_time, edges, edges_time, words, words_time);
   }
 
   // close the pipe to the forked pager
@@ -7718,7 +7743,11 @@ void Grep::search(const char *pathname)
                 out.chr('}');
               }
               out.str(color_off);
-              out.chr(flag_null ? '\0' : '\n');
+
+              if (flag_null)
+                out.chr('\0');
+              else
+                out.nl_no_flush();
             }
           }
         }
@@ -7857,7 +7886,7 @@ void Grep::search(const char *pathname)
             }
           }
           out.num(matches);
-          out.chr('\n');
+          out.nl_no_flush();
         }
       }
       else if (flag_format != NULL)
@@ -8175,14 +8204,15 @@ void Grep::search(const char *pathname)
 
             if (size > 0)
             {
-              size -= from[size - 1] == '\n';
+              bool lf_only = from[size - 1] == '\n';
+              size -= lf_only;
               if (size > 0)
               {
                 out.str(match_ms);
                 out.str(from, size);
                 out.str(match_off);
               }
-              out.nl();
+              out.nl_or_lf(lf_only);
             }
             else
             {
@@ -8226,9 +8256,11 @@ void Grep::search(const char *pathname)
               }
               else
               {
+                bool lf_only = false;
                 if (restline_size > 0)
                 {
-                  restline_size -= restline_data[restline_size - 1] == '\n';
+                  lf_only = restline_data[restline_size - 1] == '\n';
+                  restline_size -= lf_only;
                   if (restline_size > 0)
                   {
                     out.str(color_sl);
@@ -8236,7 +8268,7 @@ void Grep::search(const char *pathname)
                     out.str(color_off);
                   }
                 }
-                out.nl();
+                out.nl_or_lf(lf_only);
               }
 
               restline_data = NULL;
@@ -8357,14 +8389,15 @@ void Grep::search(const char *pathname)
               {
                 if (eol > end)
                 {
-                  eol -= end[eol - end - 1] == '\n';
+                  bool lf_only = end[eol - end - 1] == '\n';
+                  eol -= lf_only;
                   if (eol > end)
                   {
                     out.str(color_sl);
                     out.str(end, eol - end);
                     out.str(color_off);
                   }
-                  out.nl();
+                  out.nl_or_lf(lf_only);
                 }
                 else if (matcher->hit_end())
                 {
@@ -8473,14 +8506,15 @@ void Grep::search(const char *pathname)
                     {
                       if (eol > end)
                       {
-                        eol -= end[eol - end - 1] == '\n';
+                        bool lf_only = end[eol - end - 1] == '\n';
+                        eol -= lf_only;
                         if (eol > end)
                         {
                           out.str(color_sl);
                           out.str(end, eol - end);
                           out.str(color_off);
                         }
-                        out.nl();
+                        out.nl_or_lf(lf_only);
                       }
                       else if (matcher->hit_end())
                       {
@@ -8515,9 +8549,11 @@ void Grep::search(const char *pathname)
           }
           else
           {
+            bool lf_only = false;
             if (restline_size > 0)
             {
-              restline_size -= restline_data[restline_size - 1] == '\n';
+              lf_only = restline_data[restline_size - 1] == '\n';
+              restline_size -= lf_only;
               if (restline_size > 0)
               {
                 out.str(color_sl);
@@ -8525,7 +8561,7 @@ void Grep::search(const char *pathname)
                 out.str(color_off);
               }
             }
-            out.nl();
+            out.nl_or_lf(lf_only);
           }
 
           restline_data = NULL;
@@ -8671,9 +8707,11 @@ void Grep::search(const char *pathname)
               }
               else
               {
+                bool lf_only = false;
                 if (restline_size > 0)
                 {
-                  restline_size -= restline_data[restline_size - 1] == '\n';
+                  lf_only = restline_data[restline_size - 1] == '\n';
+                  restline_size -= lf_only;
                   if (restline_size > 0)
                   {
                     out.str(v_color_sl);
@@ -8681,7 +8719,7 @@ void Grep::search(const char *pathname)
                     out.str(color_off);
                   }
                 }
-                out.nl();
+                out.nl_or_lf(lf_only);
               }
 
               restline_data = NULL;
@@ -8835,6 +8873,7 @@ void Grep::search(const char *pathname)
               {
                 if (eol > end)
                 {
+                  bool lf_only = end[eol - end - 1] == '\n';
                   eol -= end[eol - end - 1] == '\n';
                   if (eol > end)
                   {
@@ -8842,7 +8881,7 @@ void Grep::search(const char *pathname)
                     out.str(end, eol - end);
                     out.str(color_off);
                   }
-                  out.nl();
+                  out.nl_or_lf(lf_only);
                 }
                 else if (matcher->hit_end())
                 {
@@ -8951,14 +8990,15 @@ void Grep::search(const char *pathname)
                     {
                       if (eol > end)
                       {
-                        eol -= end[eol - end - 1] == '\n';
+                        bool lf_only = end[eol - end - 1] == '\n';
+                        eol -= lf_only;
                         if (eol > end)
                         {
                           out.str(v_color_sl);
                           out.str(end, eol - end);
                           out.str(color_off);
                         }
-                        out.nl();
+                        out.nl_or_lf(lf_only);
                       }
                       else if (matcher->hit_end())
                       {
@@ -8993,9 +9033,11 @@ void Grep::search(const char *pathname)
           }
           else
           {
+            bool lf_only = false;
             if (restline_size > 0)
             {
-              restline_size -= restline_data[restline_size - 1] == '\n';
+              lf_only = restline_data[restline_size - 1] == '\n';
+              restline_size -= lf_only;
               if (restline_size > 0)
               {
                 out.str(v_color_sl);
@@ -9003,7 +9045,7 @@ void Grep::search(const char *pathname)
                 out.str(color_off);
               }
             }
-            out.nl();
+            out.nl_or_lf(lf_only);
           }
 
           restline_data = NULL;
@@ -9068,9 +9110,11 @@ void Grep::search(const char *pathname)
               }
               else
               {
+                bool lf_only = false;
                 if (restline_size > 0)
                 {
-                  restline_size -= restline_data[restline_size - 1] == '\n';
+                  lf_only = restline_data[restline_size - 1] == '\n';
+                  restline_size -= lf_only;
                   if (restline_size > 0)
                   {
                     out.str(color_sl);
@@ -9078,7 +9122,7 @@ void Grep::search(const char *pathname)
                     out.str(color_off);
                   }
                 }
-                out.nl();
+                out.nl_or_lf(lf_only);
               }
 
               restline_data = NULL;
@@ -9227,14 +9271,15 @@ void Grep::search(const char *pathname)
               {
                 if (eol > end)
                 {
-                  eol -= end[eol - end - 1] == '\n';
+                  bool lf_only = end[eol - end - 1] == '\n';
+                  eol -= lf_only;
                   if (eol > end)
                   {
                     out.str(color_sl);
                     out.str(end, eol - end);
                     out.str(color_off);
                   }
-                  out.nl();
+                  out.nl_or_lf(lf_only);
                 }
                 else if (matcher->hit_end())
                 {
@@ -9343,14 +9388,15 @@ void Grep::search(const char *pathname)
                     {
                       if (eol > end)
                       {
-                        eol -= end[eol - end - 1] == '\n';
+                        bool lf_only = end[eol - end - 1] == '\n';
+                        eol -= lf_only;
                         if (eol > end)
                         {
                           out.str(color_sl);
                           out.str(end, eol - end);
                           out.str(color_off);
                         }
-                        out.nl();
+                        out.nl_or_lf(lf_only);
                       }
                       else if (matcher->hit_end())
                       {
@@ -9387,9 +9433,11 @@ void Grep::search(const char *pathname)
           }
           else
           {
+            bool lf_only = false;
             if (restline_size > 0)
             {
-              restline_size -= restline_data[restline_size - 1] == '\n';
+              lf_only = restline_data[restline_size - 1] == '\n';
+              restline_size -= lf_only;
               if (restline_size > 0)
               {
                 out.str(color_sl);
@@ -9397,7 +9445,7 @@ void Grep::search(const char *pathname)
                 out.str(color_off);
               }
             }
-            out.nl();
+            out.nl_or_lf(lf_only);
           }
 
           restline_data = NULL;
@@ -9470,9 +9518,11 @@ void Grep::search(const char *pathname)
               }
               else
               {
+                bool lf_only = false;
                 if (restline_size > 0)
                 {
-                  restline_size -= restline_data[restline_size - 1] == '\n';
+                  lf_only = restline_data[restline_size - 1] == '\n';
+                  restline_size -= lf_only;
                   if (restline_size > 0)
                   {
                     out.str(color_cx);
@@ -9480,7 +9530,7 @@ void Grep::search(const char *pathname)
                     out.str(color_off);
                   }
                 }
-                out.nl();
+                out.nl_or_lf(lf_only);
               }
 
               restline_data = NULL;
@@ -9788,9 +9838,11 @@ void Grep::search(const char *pathname)
               }
               else
               {
+                bool lf_only = false;
                 if (restline_size > 0)
                 {
-                  restline_size -= restline_data[restline_size - 1] == '\n';
+                  lf_only = restline_data[restline_size - 1] == '\n';
+                  restline_size -= lf_only;
                   if (restline_size > 0)
                   {
                     out.str(color_cx);
@@ -9798,7 +9850,7 @@ void Grep::search(const char *pathname)
                     out.str(color_off);
                   }
                 }
-                out.nl();
+                out.nl_or_lf(lf_only);
               }
 
               restline_data = NULL;
@@ -9882,9 +9934,11 @@ void Grep::search(const char *pathname)
           }
           else
           {
+            bool lf_only = false;
             if (restline_size > 0)
             {
-              restline_size -= restline_data[restline_size - 1] == '\n';
+              lf_only = restline_data[restline_size - 1] == '\n';
+              restline_size -= lf_only;
               if (restline_size > 0)
               {
                 out.str(color_cx);
@@ -9892,7 +9946,7 @@ void Grep::search(const char *pathname)
                 out.str(color_off);
               }
             }
-            out.nl();
+            out.nl_or_lf(lf_only);
           }
 
           restline_data = NULL;
@@ -9924,7 +9978,7 @@ done_search:
 
       // --break: add a line break when applicable
       if (flag_break && (matches > 0 || flag_any_line) && !flag_quiet && !flag_files_with_matches && !flag_count && flag_format == NULL)
-        out.chr('\n');
+        out.nl_no_flush();
     }
 
     catch (...)

--- a/src/ugrep.hpp
+++ b/src/ugrep.hpp
@@ -84,6 +84,7 @@
 
 #define PATHSEPCHR '\\'
 #define PATHSEPSTR "\\"
+#define NEWLINESTR "\r\n" // Note: Also hard-coded into Output class.
 
 // POSIX read() and write() return type is ssize_t
 typedef int ssize_t;
@@ -224,6 +225,7 @@ inline int fopenw_s(FILE **file, const char *filename, const char *mode)
 
 #define PATHSEPCHR '/'
 #define PATHSEPSTR "/"
+#define NEWLINESTR "\n" // Note: Also hard-coded into Output class.
 
 // Windows-like dupenv_s()
 inline int dupenv_s(char **ptr, const char *name)


### PR DESCRIPTION
README.md:
- Update the README to reflect that the GLOB argument does work but that
  `-g` is still likely to be more intuitive.

input.cpp:
- Don't change file mode in file_init. Assume file is binary. (This also
  means the `enc` parameter is no longer needed.)

output.hpp:
- Convert CRLF and CR to LF before writing text to an output file.

query.cpp:
- Open pipe as binary.

ugrep.cpp:
- Open searched files and pipes as binary.
- Update usage for the -U/--binary parameter.