### PR TITLE
configure.ac: Update configure.ac file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
-AC_INIT(ugrep,3.3)
+AC_INIT([ugrep],[3.3])
 AM_INIT_AUTOMAKE([foreign])
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 AC_COPYRIGHT([Copyright (C) 2019-2020 Robert van Engelen, Genivia Inc.])
 
 AC_CONFIG_MACRO_DIR([m4])
@@ -41,27 +41,23 @@ AC_SUBST(PLATFORM)
 
 # F_RDAHEAD fcntl()
 AC_MSG_CHECKING(for F_RDAHEAD fcntl)
-AC_TRY_COMPILE([
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <fcntl.h>
-],
-[ int cmd = F_RDAHEAD; ],
-[
+]], [[ int cmd = F_RDAHEAD; ]])],[
   AC_DEFINE(HAVE_F_RDAHEAD,1,[ Define if F_RDAHEAD fcntl() is supported])
   AC_MSG_RESULT(yes)
-], AC_MSG_RESULT(no)
-)
+],[AC_MSG_RESULT(no)
+])
 
 # O_NOATIME open flag
 AC_MSG_CHECKING(for O_NOATIME open flag)
-AC_TRY_COMPILE([
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <fcntl.h>
-],
-[ int cmd = O_NOATIME; ],
-[
+]], [[ int cmd = O_NOATIME; ]])],[
   AC_DEFINE(HAVE_O_NOATIME,1,[ Define if O_NOATIME open flag is supported])
   AC_MSG_RESULT(yes)
-], AC_MSG_RESULT(no)
-)
+],[AC_MSG_RESULT(no)
+])
 
 AX_CHECK_PCRE2([8],
 [],
@@ -83,8 +79,7 @@ AX_CHECK_LZ4LIB([], [echo "liblz4 not found: ugrep option -z won't decompress .l
 AX_CHECK_ZSTDLIB([], [echo "libzstd not found: ugrep option -z won't decompress .zst files"])
 
 AC_ARG_WITH(grep-path,
-  [AC_HELP_STRING([--with-grep-path=GREP_PATH],
-                  [specifies the GREP_PATH if different than the default DATAROOTDIR/ugrep/patterns])],
+  [AS_HELP_STRING([--with-grep-path=GREP_PATH],[specifies the GREP_PATH if different than the default DATAROOTDIR/ugrep/patterns])],
   [with_grep_path="$withval"],
   [with_grep_path=""])
 AC_MSG_CHECKING(for --with-grep-path)
@@ -98,8 +93,7 @@ fi
 AC_SUBST(GREP_PATH)
 
 AC_ARG_WITH(grep-colors,
-  [AC_HELP_STRING([--with-grep-colors="GREP_COLORS"],
-                  [specifies the default ANSI SGR color parameters when variable GREP_COLORS is undefined])],
+  [AS_HELP_STRING([--with-grep-colors="GREP_COLORS"],[specifies the default ANSI SGR color parameters when variable GREP_COLORS is undefined])],
   [with_grep_colors="$withval"],
   [with_grep_colors=""])
 AC_MSG_CHECKING(for --with-grep-colors)
@@ -111,8 +105,7 @@ else
 fi
 
 AC_ARG_ENABLE(auto-color,
-  [AC_HELP_STRING([--disable-auto-color],
-                  [disable automatic colors, otherwise colors are enabled by default])],
+  [AS_HELP_STRING([--disable-auto-color],[disable automatic colors, otherwise colors are enabled by default])],
   [with_no_auto_color="yes"],
   [with_no_auto_color="no"])
 AC_MSG_CHECKING(for --disable-auto-color)
@@ -124,8 +117,7 @@ else
 fi
 
 AC_ARG_ENABLE(color,
-  [AC_HELP_STRING([--enable-color],
-                  [deprecated, use --disable-auto-color])],
+  [AS_HELP_STRING([--enable-color],[deprecated, use --disable-auto-color])],
   [],
   [])
 AC_MSG_CHECKING(for --enable-color)
@@ -136,8 +128,7 @@ else
 fi
 
 AC_ARG_ENABLE(pretty,
-  [AC_HELP_STRING([--enable-pretty],
-                  [enable pretty output by default without requiring ugrep flag --pretty])],
+  [AS_HELP_STRING([--enable-pretty],[enable pretty output by default without requiring ugrep flag --pretty])],
   [with_pretty="$enable_pretty"],
   [with_pretty="no"])
 AC_MSG_CHECKING(for --enable-pretty)
@@ -149,8 +140,7 @@ else
 fi
 
 AC_ARG_ENABLE(pager,
-  [AC_HELP_STRING([--enable-pager],
-                  [enable the pager by default without requiring ugrep flag --pager])],
+  [AS_HELP_STRING([--enable-pager],[enable the pager by default without requiring ugrep flag --pager])],
   [with_pager="$enable_pager"],
   [with_pager="no"])
 AC_MSG_CHECKING(for --enable-pager)
@@ -162,8 +152,7 @@ else
 fi
 
 AC_ARG_ENABLE(hidden,
-  [AC_HELP_STRING([--enable-hidden],
-                  [enable searching hidden files and directories by default unless explicitly disabled with ugrep flag --no-hidden])],
+  [AS_HELP_STRING([--enable-hidden],[enable searching hidden files and directories by default unless explicitly disabled with ugrep flag --no-hidden])],
   [with_hidden="yes"],
   [with_hidden="no"])
 AC_MSG_CHECKING(for --enable-hidden)
@@ -175,8 +164,7 @@ else
 fi
 
 AC_ARG_ENABLE(mmap,
-  [AC_HELP_STRING([--disable-mmap],
-                  [disable memory mapped files unless explicitly enabled with --mmap])],
+  [AS_HELP_STRING([--disable-mmap],[disable memory mapped files unless explicitly enabled with --mmap])],
   [with_no_mmap="yes"],
   [with_no_mmap="no"])
 AC_MSG_CHECKING(for --disable-mmap)
@@ -190,8 +178,7 @@ fi
 AC_SUBST(EXTRA_CFLAGS)
 
 AC_ARG_ENABLE(sse2,
-  [AC_HELP_STRING([--disable-sse2],
-                  [disable SSE2 and AVX optimizations])],
+  [AS_HELP_STRING([--disable-sse2],[disable SSE2 and AVX optimizations])],
   [with_no_sse2="yes"],
   [with_no_sse2="no"])
 AC_MSG_CHECKING(for --disable-sse2)
@@ -208,8 +195,7 @@ if test "x$with_no_sse2" = "xno"; then
   if test "x$msse2_ok" = "xyes"; then
     SIMD_FLAGS="-msse2 -DHAVE_SSE2"
     AC_ARG_ENABLE(avx,
-      [AC_HELP_STRING([--disable-avx],
-                      [disable AVX optimizations])],
+      [AS_HELP_STRING([--disable-avx],[disable AVX optimizations])],
       [with_no_avx="yes"],
       [with_no_avx="no"])
     AC_MSG_CHECKING(for --disable-avx)
@@ -247,8 +233,7 @@ fi
 
 if test "x$SIMD_FLAGS" = "x"; then
 AC_ARG_ENABLE(neon,
-  [AC_HELP_STRING([--disable-neon],
-                  [disable ARM NEON/AArch64 optimizations])],
+  [AS_HELP_STRING([--disable-neon],[disable ARM NEON/AArch64 optimizations])],
   [with_no_neon="yes"],
   [with_no_neon="no"])
 AC_MSG_CHECKING(for --disable-neon)


### PR DESCRIPTION
Solve warnings while running autotools

configure.ac:3: warning: 'AM_CONFIG_HEADER': this macro is obsolete.
configure.ac:3: You should use the 'AC_CONFIG_HEADERS' macro instead.
./lib/autoconf/general.m4:2434: AC_DIAGNOSE is expanded from...
aclocal.m4:805: AM_CONFIG_HEADER is expanded from...
configure.ac:3: the top level
configure.ac:44: warning: The macro `AC_TRY_COMPILE' is obsolete.
configure.ac:44: You should run autoupdate.
./lib/autoconf/general.m4:2847: AC_TRY_COMPILE is expanded from...
configure.ac:44: the top level
configure.ac:56: warning: The macro `AC_TRY_COMPILE' is obsolete.
configure.ac:56: You should run autoupdate.
./lib/autoconf/general.m4:2847: AC_TRY_COMPILE is expanded from...
configure.ac:56: the top level
configure.ac:85: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:85: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
./lib/autoconf/general.m4:1553: AC_ARG_WITH is expanded from...
configure.ac:85: the top level
configure.ac:100: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:100: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
./lib/autoconf/general.m4:1553: AC_ARG_WITH is expanded from...
configure.ac:100: the top level
configure.ac:113: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:113: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
./lib/autoconf/general.m4:1534: AC_ARG_ENABLE is expanded from...
configure.ac:113: the top level
configure.ac:126: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:126: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
./lib/autoconf/general.m4:1534: AC_ARG_ENABLE is expanded from...
configure.ac:126: the top level
configure.ac:138: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:138: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
./lib/autoconf/general.m4:1534: AC_ARG_ENABLE is expanded from...
configure.ac:138: the top level
configure.ac:151: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:151: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
./lib/autoconf/general.m4:1534: AC_ARG_ENABLE is expanded from...
configure.ac:151: the top level
configure.ac:164: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:164: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
./lib/autoconf/general.m4:1534: AC_ARG_ENABLE is expanded from...
configure.ac:164: the top level
configure.ac:177: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:177: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
./lib/autoconf/general.m4:1534: AC_ARG_ENABLE is expanded from...
configure.ac:177: the top level
configure.ac:192: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:192: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
./lib/autoconf/general.m4:1534: AC_ARG_ENABLE is expanded from...
configure.ac:192: the top level
configure.ac:207: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:207: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
./lib/autoconf/general.m4:1534: AC_ARG_ENABLE is expanded from...
configure.ac:207: the top level
configure.ac:243: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:243: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
./lib/autoconf/general.m4:1534: AC_ARG_ENABLE is expanded from...

Signed-off-by: Ricardo Ribalda <ricardo@ribalda.com>