### PR TITLE
Support "cpp" as a file type

### DIFF
--- a/src/ugrep.cpp
+++ b/src/ugrep.cpp
@@ -3803,6 +3803,7 @@ const Type type_table[] = {
   { "c",            "c,h,H,hdl,xs", NULL,                                             NULL },
   { "c++",          "cpp,CPP,cc,cxx,CXX,h,hh,H,hpp,hxx,Hxx,HXX", NULL,                NULL },
   { "clojure",      "clj", NULL,                                                      NULL },
+  { "cpp",          "cpp,CPP,cc,cxx,CXX,h,hh,H,hpp,hxx,Hxx,HXX", NULL,                NULL },
   { "csharp",       "cs", NULL,                                                       NULL },
   { "css",          "css", NULL,                                                      NULL },
   { "csv",          "csv", NULL,                                                      NULL },


### PR DESCRIPTION
Searching for CPP files currently requires `-t c++`, which is
surprisingly awkward to type quickly since some (but not all) characters
require SHIFT. `C++` would be a bit better, but why not just accept `cpp`?