### PR TITLE
add more binary paths to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@
 
 # Executables
 a.out
+bin/ug
+bin/ugrep
+src/ugrep
 
 # Autotools
 .deps/


### PR DESCRIPTION
Not sure if these were left out of .gitignore intentionally, or if I did something wrong when installing. But I followed the installation instructions (git clone https://github.com/Genivia/ugrep && cd ugrep && ./build.sh) and these 3 executables were create (bin/ug, bin/ugrep, and src/ugrep). I figured they should be added to .gitignore.