### PR TITLE
Fix path to patterns directory for out-of-source builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -912,7 +912,7 @@ install-exec-hook:
 
 install-data-hook:
 		mkdir -p $(DESTDIR)$(datadir)/ugrep && \
-		  cp -rf patterns $(DESTDIR)$(datadir)/ugrep/
+		  cp -rf $(top_srcdir)/patterns $(DESTDIR)$(datadir)/ugrep/
 		cd $(DESTDIR)$(mandir)/man1; \
 		  rm -f ug.1; \
 		  $(LN_S) ugrep.1 ug.1


### PR DESCRIPTION
make install fails for out-of-source builds with this error
```bash
make  install-data-hook
make[3]: Entering directory 'ugrep/build'
mkdir -p ugrep/install/share/ugrep && \
          cp -rf patterns ugrep/install/share/ugrep/
cp: cannot stat 'patterns': No such file or directory
make[3]: *** [Makefile:914: install-data-hook] Error 1
make[3]: Leaving directory 'ugrep/build'
make[2]: *** [Makefile:820: install-data-am] Error 2
make[2]: Leaving directory 'ugrep/build'
make[1]: *** [Makefile:773: install-am] Error 2
make[1]: Leaving directory 'ugrep/build'
make: *** [Makefile:464: install-recursive] Error 1
```

This PR prepends `$(top_srcdir)` to `patterns` in the source tree to form a correct path

Fixes #219