### PR TITLE
ug+ / ugrep+ can use /bin/sh rather than /bin/bash

### DIFF
--- a/bin/ug+
+++ b/bin/ug+
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 filters=
 if [ -x "$(command -v pdftotext)" ] && pdftotext --help 2>&1 | ugrep -qw Poppler ; then
   filters="${filters}${filters:+,}pdf:pdftotext % -"

--- a/bin/ugrep+
+++ b/bin/ugrep+
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 filters=
 if [ -x "$(command -v pdftotext)" ] && pdftotext --help 2>&1 | ugrep -qw Poppler ; then
   filters="${filters}${filters:+,}pdf:pdftotext % -"


### PR DESCRIPTION
* No bash specific features are used, both scripts are valid Posix sh according to shellcheck
* Improves portability to platforms that don't have bash under /bin/