### PR TITLE
fix include for ptrdiff_t for older systems (#277)

### DIFF
--- a/lib/simd_avx2.cpp
+++ b/lib/simd_avx2.cpp
@@ -35,6 +35,7 @@
 */
 
 #include <reflex/absmatcher.h>
+#include <cstddef>
 
 namespace reflex {
 
@@ -48,7 +49,7 @@ size_t simd_nlcount_avx2(const char*& b, const char *e)
     return 0;
   size_t n = 0;
   // align on 32 bytes
-  while ((reinterpret_cast<ptrdiff_t>(s) & 0x1f) != 0)
+  while ((reinterpret_cast<std::ptrdiff_t>(s) & 0x1f) != 0)
     n += (*s++ == '\n');
   __m256i vlcn = _mm256_set1_epi8('\n');
   while (s <= e)
@@ -82,7 +83,7 @@ size_t simd_nlcount_sse2(const char*& b, const char *e)
     return 0;
   size_t n = 0;
   // align on 16 bytes
-  while ((reinterpret_cast<ptrdiff_t>(s) & 0x0f) != 0)
+  while ((reinterpret_cast<std::ptrdiff_t>(s) & 0x0f) != 0)
     n += (*s++ == '\n');
   __m128i vlcn = _mm_set1_epi8('\n');
   while (s <= e)


### PR DESCRIPTION
`ptrdiff_t` is in `stddef.h`, or `std::ptrdiff_t` is in `cstddef`. I have no idea why it works on newer systems.

Fixes https://github.com/Genivia/ugrep/issues/277