### PR TITLE
Fix --enable-hidden option

### DIFF
--- a/configure
+++ b/configure
@@ -8418,7 +8418,7 @@ fi
 # Check whether --enable-hidden was given.
 if test ${enable_hidden+y}
 then :
-  enableval=$enable_hidden; with_hidden="yes"
+  enableval=$enable_hidden; with_hidden="$enable_hidden"
 else $as_nop
   with_hidden="no"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -160,7 +160,7 @@ fi
 AC_ARG_ENABLE(hidden,
   [AS_HELP_STRING([--enable-hidden],
                   [enable searching hidden files and directories by default unless explicitly disabled with ugrep flag --no-hidden])],
-  [with_hidden="yes"],
+  [with_hidden="$enable_hidden"],
   [with_hidden="no"])
 AC_MSG_CHECKING(for --enable-hidden)
 if test "x$with_hidden" = "xno"; then


### PR DESCRIPTION
Part of configure output with port option hidden disabled:
checking for --disable-auto-color... no
checking for --enable-color... yes
checking for --enable-pretty... yes
checking for --enable-pager... yes
checking for --enable-hidden... yes
checking for --disable-mmap... yes
checking for --disable-sse2... no

As a result ug searches in hidden directories/files.


As reported in [FreeBSD bug #273226](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=273226)