### PR TITLE
Add Zig support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4636,7 +4636,7 @@ in markdown:
                   `rust', `scala', `scheme', `shell', `Shell', `smalltalk', `sql',
                   `svg', `swift', `tcl', `tex', `text', `tiff', `Tiff', `tt',
                   `typescript', `verilog', `vhdl', `vim', `xml', `Xml', `yacc',
-                  `yaml'.
+                  `yaml', 'zig'.
 
            --tabs[=NUM]
                   Set the tab size to NUM to expand tabs for option -k.  The value

--- a/man/ugrep.1
+++ b/man/ugrep.1
@@ -791,7 +791,7 @@ file types can be (where \fB\-t\fRlist displays a detailed list):
 `scala', `scheme', `shell', `Shell', `smalltalk', `sql', `svg',
 `swift', `tcl', `tex', `text', `tiff', `Tiff', `tt',
 `typescript', `verilog', `vhdl', `vim', `xml', `Xml', `yacc',
-`yaml'.
+`yaml', 'zig'.
 .TP
 \fB\-\-tabs\fR[=\fINUM\fR]
 Set the tab size to NUM to expand tabs for option \fB\-k\fR.  The value of

--- a/src/ugrep.cpp
+++ b/src/ugrep.cpp
@@ -4483,6 +4483,7 @@ const Type type_table[] = {
   { "Xml",          "xml,xsd,xsl,xslt,wsdl,rss,svg,ent,plist", NULL,                  "<\\?xml " },
   { "yacc",         "y", NULL,                                                        NULL },
   { "yaml",         "yaml,yml", NULL,                                                 NULL },
+  { "zig",          "zig,zon", NULL,                                                  NULL },
   { NULL,           NULL, NULL,                                                       NULL }
 };
 


### PR DESCRIPTION
This PR adds support for filtering Zig files.
It adds support for the standard Zig source files, as well as the Zig object notation ZON.