### PR TITLE
Fixes #313 fix segfault and hang when zlib inflate ret value is below 0

### DIFF
--- a/src/zstream.hpp
+++ b/src/zstream.hpp
@@ -450,6 +450,9 @@ class zstreambuf : public std::streambuf {
               cannot_decompress(pathname_, "a zlib decompression error was detected in the zip compressed data");
               num = -1;
               zend_ = true;
+              if (ret < Z_OK) {
+                return false;
+              }
             }
             else
             {
@@ -481,6 +484,9 @@ class zstreambuf : public std::streambuf {
                 cannot_decompress(pathname_, "a zlib decompression error was detected in the zip compressed data");
                 num = -1;
                 zend_ = true;
+                if (ret < Z_OK) {
+                  return false;
+                }
               }
               else
               {
@@ -507,6 +513,9 @@ class zstreambuf : public std::streambuf {
             {
               cannot_decompress(pathname_, "a zlib decompression error was detected in the zip compressed data");
               num = -1;
+              if (ret < Z_OK) {
+                return false;
+              }
             }
           }
 


### PR DESCRIPTION
it seems when you call inflate again when the last inflate call return code is below zero, zlib just crash.