### PR TITLE
Refactor Dockerfile for optimized build speed and image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,25 +12,35 @@
 # debian or ubuntu
 FROM ubuntu
 
-RUN apt-get update
-
-RUN apt-get install -y \
-    make \
-    vim \
-    git \
-    clang \
-    wget \
-    unzip \
-    libpcre2-dev \
-    libz-dev \
-    libbz2-dev \
-    liblzma-dev \
-    liblz4-dev \
-    libzstd-dev
-
-RUN cd / &&\
-    git clone https://github.com/Genivia/ugrep
-
-RUN cd ugrep &&\
-    ./build.sh &&\
-    make install
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        make \
+        vim \
+        git \
+        clang \
+        wget \
+        unzip \
+        ca-certificates \
+        libpcre2-dev \
+        libz-dev \
+        libbz2-dev \
+        liblzma-dev \
+        liblz4-dev \
+        libzstd-dev && \
+    git clone --depth=1 https://github.com/Genivia/ugrep && \
+    cd ugrep && \
+    ./build.sh && \
+    make install && \
+    ugrep -V && \
+    cd ../ && \
+    rm -rf ugrep && \
+    apt-get remove -y \
+        make \
+        git \
+        libpcre2-dev \
+        libz-dev \
+        libbz2-dev \
+        liblzma-dev \
+        liblz4-dev \
+        libzstd-dev && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
By properly handling the layers and temp, the image size and build speed are significantly improved!

Here's the size change before and after the optimization:
```
REPOSITORY          TAG                  IMAGE ID       CREATED         SIZE
ugrep               after                8809a59b7579   8 days ago      548MB
ugrep               before               d329eedc0405   8 days ago      1.07GB
```