### PR TITLE
Add Macports moar +pager variant (moar-pager)

### DIFF
--- a/src/query.cpp
+++ b/src/query.cpp
@@ -2328,20 +2328,21 @@ void Query::view()
       !flag_count &&
       !flag_hex &&
       !flag_with_hex &&
-      (command == "less"  ||
-       command == "moar"  ||
-       command == "more"  ||
-       command == "most"  ||
-       command == "w3m"   ||
-       command == "emacs" ||
-       command == "joe"   ||
-       command == "vi"    ||
-       command == "vim"   ||
-       command == "vis"   ||
-       command == "kak"   ||
-       command == "nano"  ||
-       command == "pico"  ||
-       command == "vile"  ||
+      (command == "less"       ||
+       command == "moar-pager" ||
+       command == "moar"       ||
+       command == "more"       ||
+       command == "most"       ||
+       command == "w3m"        ||
+       command == "emacs"      ||
+       command == "joe"        ||
+       command == "vi"         ||
+       command == "vim"        ||
+       command == "vis"        ||
+       command == "kak"        ||
+       command == "nano"       ||
+       command == "pico"       ||
+       command == "vile"       ||
        command == "zile"))
   {
     line_number = get_line_number();


### PR DESCRIPTION
In macports/macports-ports#21604, the MacPorts team merged a way of
installing the `moar` pager (support for `moar` was added to `ugrep`
@295382bc72) that renames the installed binary to `moar-pager` because
`moar` conflicts with name of the Rakudo virtual machine (MoarVM). This
is not the default variant, but it will be used by MacPorts users who
prefer `moar` to `less` and also develop nqp or Rakudo (and therefore
require MoarVM).

This patches `ugrep` to check the `$PAGER` command for `moar-pager`
before `moar`, the same as we now do in the `ugrep` port.

Merging this will allow us to no longer require a patch to the port
distribution and continue distributing upstream unmodified, which is our
preference.
