### PR TITLE
add `installers-regex` to Winget Releaser workflow

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -11,4 +11,5 @@ jobs:
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: Genivia.ugrep
+          installers-regex: '-windows-\w+\.zip$'
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
- Continuation of #301

Winget Releaser does not match zip files by default, so a regex must be added.