### PR TITLE
remove shebang from bash completion script

### DIFF
--- a/completions/bash/ug
+++ b/completions/bash/ug
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # bash completion for ug and ugrep
 # recommended: add the following lines to ~/.inputrc
 # set colored-stats on


### PR DESCRIPTION
Bash completion scripts are sourced, not executed. Hence they do not need a shebang. Removing it fixes rpmlint packaging warnings that are thrown in this or similar forms in distros.

````
ugrep-bash-completion.noarch: W: symlink-to-binary-with-shebang /usr/share/bash-completion/completions/ug+ is a link to a script (/usr/share/bash-completion/completions/ug) but missing requires for /usr/bin/env
ugrep-bash-completion.noarch: W: symlink-to-binary-with-shebang /usr/share/bash-completion/completions/ugrep is a link to a script (/usr/share/bash-completion/completions/ug) but missing requires for /usr/bin/env
ugrep-bash-completion.noarch: W: symlink-to-binary-with-shebang /usr/share/bash-completion/completions/ugrep+ is a link to a script (/usr/share/bash-completion/completions/ug) but missing requires for /usr/bin/env
A file in /usr/bin is a link to a script in a different place with a shebang.
rpm won't be able to inject the needed interpreter as dependency, so it should
be done manually.
````

````
ugrep-bash-completion.noarch: E: non-executable-script /usr/share/bash-completion/completions/ug 644 /usr/bin/env bash
This text file contains a shebang or is located in a path dedicated for
executables, but lacks the executable bits and cannot thus be executed. If the
file is meant to be an executable script, add the executable bits, otherwise
remove the shebang or move the file elsewhere.
````