### PR TITLE
7zip: Do not build when configured with disable-7zip

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,10 @@
-SUBDIRS = lib lzma/C src
+SUBDIRS = lib
+
+if ENABLE_7ZIP
+SUBDIRS += lzma/C
+endif
+
+SUBDIRS += src
 
 man1_MANS = man/ugrep.1
 

--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,7 @@ else
 fi
 
 fi
+AM_CONDITIONAL([ENABLE_7ZIP],[test "x$with_7zip" = "xyes"])
 
 AC_ARG_WITH([bash-completion-dir],
   [AS_HELP_STRING([--with-bash-completion-dir[=PATH]],


### PR DESCRIPTION
If the user decided to not use 7zip do not try to build it. It might fail to build on arm32 arches.

https://buildd.debian.org/status/fetch.php?pkg=ugrep&arch=armhf&ver=4.5.1%2Bdfsg-2&stamp=1704748410&file=log 7zCrc.c:172:1: error: ‘-mfloat-abi=hard’: selected architecture lacks an FPU