### PR TITLE
Fix avx512bw configure test

### DIFF
--- a/configure
+++ b/configure
@@ -8777,7 +8777,7 @@ printf %s "checking whether ${CXX} supports AVX2/AVX512BW intrinsics... " >&6; }
 int
 main (void)
 {
-__m512 n = _mm512_set1_epi8(42); (void)_mm512_cmpeq_epi8_mask(n, n);
+__m512i n = _mm512_set1_epi8(42); (void)_mm512_cmpeq_epi8_mask(n, n);
   ;
   return 0;
 }
@@ -8976,7 +8976,7 @@ else $as_nop
 int
 main (void)
 {
-__m512 n = _mm512_set1_epi8(42); (void)_mm512_cmpeq_epi8_mask(n, n);
+__m512i n = _mm512_set1_epi8(42); (void)_mm512_cmpeq_epi8_mask(n, n);
   ;
   return 0;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -106,7 +106,7 @@ if test "x$cross_compiling" = "xyes"; then
             AC_MSG_CHECKING([whether ${CXX} supports AVX2/AVX512BW intrinsics])
             save_CXXFLAGS=$CXXFLAGS
             CXXFLAGS="-mavx512bw"
-            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <immintrin.h>]], [[__m512 n = _mm512_set1_epi8(42); (void)_mm512_cmpeq_epi8_mask(n, n);]])],
+            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <immintrin.h>]], [[__m512i n = _mm512_set1_epi8(42); (void)_mm512_cmpeq_epi8_mask(n, n);]])],
                               [mavx_ok=yes],
                               [mavx_ok=no])
             if test "x$mavx_ok" = "xyes"; then
@@ -190,7 +190,7 @@ else
         AC_MSG_CHECKING([whether ${CXX} supports AVX2/AVX512BW intrinsics])
         save_CXXFLAGS=$CXXFLAGS
         CXXFLAGS="-mavx512bw"
-        AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <immintrin.h>]],[[__m512 n = _mm512_set1_epi8(42); (void)_mm512_cmpeq_epi8_mask(n, n);]])],
+        AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <immintrin.h>]],[[__m512i n = _mm512_set1_epi8(42); (void)_mm512_cmpeq_epi8_mask(n, n);]])],
                       [mavx_ok=yes],
                       [mavx_ok=no])
         if test "x$mavx_ok" = "xyes"; then


### PR DESCRIPTION
Unlike clang, gcc fails when using __m512 instead of __m512i.