### PR TITLE
Allow static building with `./build.sh --enable-static`

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,9 @@ from `/usr/local/lib`, causing a library load error when running `ugrep`.  To
 correct this, add `export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"` to
 your `~/.bashrc` file.  Or run `sudo ldconfig /usr/local/lib`.
 
+**Note:** you can build static executables by supplying `--enable-static`
+as an argument to `./build.sh`.
+
 ### Other platforms: step 3 build
 
 Build `ugrep` on Unix-like systems with colors enabled by default:

--- a/configure.ac
+++ b/configure.ac
@@ -390,6 +390,24 @@ AC_SUBST(ZSH_COMPLETION_DIR)
 AM_CONDITIONAL([ENABLE_ZSH_COMPLETION],[test "x$with_zsh_completion_dir" != "xno"])
 
 ################################################################################
+# Static or dynamic (default) linking
+################################################################################
+
+AC_ARG_ENABLE(static,
+  [AS_HELP_STRING([--enable-static],
+                  [build static ugrep binaries])],
+              [enable_static=yes],
+              [enable_static=no])
+AC_MSG_CHECKING(for --enable-static)
+if test "x$enable_static" == "xyes"; then
+  CFLAGS="$CFLAGS -static"
+  LDFLAGS="$LDFLAGS -static"
+  AC_MSG_RESULT(yes)
+else
+  AC_MSG_RESULT(no)
+fi
+
+################################################################################
 # Installation preferences
 ################################################################################
 


### PR DESCRIPTION
Closes #373

Please run `autoreconf -iv` to update the autotools files in the repo from the updated `configure.ac` and commit that, too.
Debian has 2.72 only in experimental and running an update on the 2.71 in stable / testing / unstable is just creating a lot of noise.
