### PR TITLE
Update Winget Releaser action

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: Genivia.ugrep
           installers-regex: '-windows-\w+\.zip$'


### PR DESCRIPTION
`vedantmgoyal2009/winget-releaser@v2` has moved to `vedantmgoyal9/winget-releaser@main` (`v2` has also not been updated for over a year as well). 