### PR TITLE
bin/ug(|rep)+: Let the helper script work if no helper is available

### DIFF
--- a/bin/ug+
+++ b/bin/ug+
@@ -12,4 +12,8 @@ fi
 if [ -x "$(command -v exiftool)" ] ; then
   filters="${filters}${filters:+,}gif,jpg,jpeg,mpg,mpeg,png,tiff:exiftool %"
 fi
-ug --filter="${filters}" "$@"
+if [ -n "$filters" ]; then
+  ug --filter="${filters}" "$@"
+else
+  ug "$@"
+fi

--- a/bin/ugrep+
+++ b/bin/ugrep+
@@ -12,4 +12,8 @@ fi
 if [ -x "$(command -v exiftool)" ] ; then
   filters="${filters}${filters:+,}gif,jpg,jpeg,mpg,mpeg,png,tiff:exiftool %"
 fi
-ugrep --filter="${filters}" "$@"
+if [ -n "$filters" ]; then
+  ug --filter="${filters}" "$@"
+else
+  ug "$@"
+fi


### PR DESCRIPTION
With this patch:
ribalda@penguin:~/work/ugrep$ ./bin/ug+ root /etc/passwd
     1: root:x:0:0:root:/root:/bin/bash

Without this patch:
ribalda@penguin:~/work/ugrep$ /bin/ug+ root /etc/passwd