### PR TITLE
The `moar` pager has been renamed to `moor`

### DIFF
--- a/src/query.cpp
+++ b/src/query.cpp
@@ -2395,6 +2395,7 @@ void Query::view()
       (command == "less"       ||
        command == "moar-pager" ||
        command == "moar"       ||
+       command == "moor"       ||
        command == "more"       ||
        command == "most"       ||
        command == "w3m"        ||


### PR DESCRIPTION
Keeping the old name for backwards compatibility.

Ref: https://github.com/walles/moor/pull/305

The old GitHub project was renamed, and now redirects to the new one, so if you want to verify this is the same project, go to the old project and you will be redirected:

`https://github.com/walles/moar/pull/305`
