### PR TITLE
update Makefile to support check as an alias for test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -122,7 +122,7 @@ uninstall-hook:
 
 .PHONY:		test
 
-test:		${UGREP}
+test check:		${UGREP}
 		@echo
 		@echo "*** SINGLE-THREADED TESTS ***"
 		@echo


### PR DESCRIPTION
Automated build infrastructure such as Gentoo Linux default build phases, may check for both, and if "make check" exists it is assumed to work. But all automake generated Makefiles provide a "check" target, which either does nothing, or runs `TESTS = ....` defined via: https://www.gnu.org/software/automake/manual/html_node/Tests.html

By adding an alias, we guarantee that the custom test suite still runs, and it isn't necessary to override the automated phase definitions.