### PR TITLE
fix <sys/cpuset.h> not detected on FreeBSD

### DIFF
--- a/configure
+++ b/configure
@@ -5576,12 +5576,6 @@ then :
   printf "%s\n" "#define HAVE_SYS_MOUNT_H 1" >>confdefs.h
 
 fi
-ac_fn_cxx_check_header_compile "$LINENO" "sys/cpuset.h" "ac_cv_header_sys_cpuset_h" "$ac_includes_default"
-if test "x$ac_cv_header_sys_cpuset_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_SYS_CPUSET_H 1" >>confdefs.h
-
-fi
 ac_fn_cxx_check_header_compile "$LINENO" "sys/resource.h" "ac_cv_header_sys_resource_h" "$ac_includes_default"
 if test "x$ac_cv_header_sys_resource_h" = xyes
 then :
@@ -5592,6 +5586,20 @@ ac_fn_cxx_check_header_compile "$LINENO" "sched.h" "ac_cv_header_sched_h" "$ac_i
 if test "x$ac_cv_header_sched_h" = xyes
 then :
   printf "%s\n" "#define HAVE_SCHED_H 1" >>confdefs.h
+
+fi
+
+
+ac_fn_cxx_check_header_compile "$LINENO" "sys/cpuset.h" "ac_cv_header_sys_cpuset_h" "
+$ac_includes_default
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+
+"
+if test "x$ac_cv_header_sys_cpuset_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_SYS_CPUSET_H 1" >>confdefs.h
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,13 @@ AC_STRUCT_DIRENT_D_TYPE
 
 AC_FUNC_MMAP
 
-AC_CHECK_HEADERS([sys/time.h sys/statvfs.h sys/param.h sys/mount.h sys/cpuset.h sys/resource.h sched.h])
+AC_CHECK_HEADERS([sys/time.h sys/statvfs.h sys/param.h sys/mount.h sys/resource.h sched.h])
+AC_CHECK_HEADERS([sys/cpuset.h],[],[],[
+$ac_includes_default
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+])
 
 AC_CHECK_FUNCS([statfs statvfs])
 


### PR DESCRIPTION
On some FreeBSDs, `configure` could not detect `<sys/cpuset.h>`, because it tried to include it without `<sys/param.h>`, while (as seen in [the man page for `cpuset_setaffinity()`](https://man.freebsd.org/cgi/man.cgi?query=cpuset_setaffinity&sektion=2&n=1)), they should work in pair.

#### Why?

This is likely due to an autoconf bug:\
the historic list of headers included by `AC_INCLUDES_DEFAULT` [ends with `<sys/stat.h>` and `<unistd.h>`](https://www.gnu.org/software/autoconf/manual/autoconf-2.72/html_node/Default-Includes.html#index-AC_005fINCLUDES_005fDEFAULT-1), _without `<sys/param.h>`_,\
while in paradox `ac_header_cxx_list` defines the `HAVE_…_H` macros until `HAVE_SYS_TYPES_H`, `HAVE_UNISTD_H`, _plus `HAVE_SYS_PARAM_H`_.

#### What happens?

However, the detection for the function `cpuset_setaffinity()` works well, in the same `configure`.

So we end up with:
* `HAVE_SYS_CPUSET_H` _undefined_
  (→ no `#include <sys/cpuset.h>`),
* while `HAVE_CPUSET_SETAFFINITY` is _defined_\
  (→ in `set_this_thread_affinity_and_priority()`, the `#elif defined(__FreeBSD__) && defined(HAVE_CPUSET_SETAFFINITY)` block gets compiled).

**→ The compilation fails with undefined types and macros.**

#### Fixing

I put the test for `<sys/cpuset.h>` apart from the other includes, appending `<sys/param.h>` to the preincluded files, similarly to [what openldap did](https://git.openldap.org/openldap/openldap/-/blob/master/configure.ac#L871-876) for a similar need (for `<ucred.h>`).