### PR TITLE
fix zsh completion syntax error

### DIFF
--- a/completions/zsh/_ugrep
+++ b/completions/zsh/_ugrep
@@ -110,7 +110,7 @@ $matchers{-P,--perl-regexp}'[Interpret PATTERN as a Perl regular expression usin
 '(1)*'{-t,--file-type=-}'[Search only files associated with TYPES, a comma-separated list of file types]:TYPES:(actionscript ada adoc asm asp aspx autoconf automake awk Awk basic batch bison c c++ clojure cpp csharp css csv dart Dart delphi elisp elixir erlang fortran gif Gif go groovy gsp haskell html jade java jpeg Jpeg js json jsp julia kotlin less lex lisp lua m4 make markdown matlab node Node objc objc++ ocaml parrot pascal pdf Pdf perl Perl php Php png Png prolog python Python r rpm Rpm rst rtf Rtf ruby Ruby rust scala scheme seed7 shell Shell smalltalk sql svg swift tcl tex text tiff Tiff tt typescript verilog vhdl vim xml Xml yacc yaml zig )'
 --tabs'[Set the tab size to NUM to expand tabs for option -k]'
 --tag'[Disables colors to mark up matches with TAG]'
-{--tree,-^}'[Output directories with matching files in a tree-like format for option -c or --count, -l or --files-with-matches, -L or --files-without-match]'
+{--tree,-'^'}'[Output directories with matching files in a tree-like format for option -c or --count, -l or --files-with-matches, -L or --files-without-match]'
 {-U,--ascii,--binary}'[Disables Unicode matching for ASCII and binary matching]'
 {-u,--ungroup}'[Do not group multiple pattern matches on the same matched line]'
 {-V,--version}'[Display version with linked libraries and exit]'


### PR DESCRIPTION
There's a bug where a literal `^` during tab completion causes all subsequent passed flags to stop appearing, as well as causing error messages in some directories.

To reproduce, try completing `--zmax`.