### PR TITLE
fix #518: relate ignore-files to exclude-from in the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1966,6 +1966,8 @@ Same, but with pretty output with headings, line numbers and column numbers
             a `/'.  Files and directories explicitly specified as command line
             arguments are never ignored.  This option may be repeated to
             specify additional files.
+            See also related option --exclude-from for a global set of
+            exclusions.
     -g GLOBS, --glob=GLOBS
             Search only files whose name matches the specified comma-separated
             list of GLOBS, same as --include='glob' for each `glob' in GLOBS.
@@ -2256,6 +2258,8 @@ search the files:
             a `/'.  Files and directories explicitly specified as command line
             arguments are never ignored.  This option may be repeated to
             specify additional files.
+            See also related option --exclude-from for a global set of
+            exclusions.
     -M MAGIC, --file-magic=MAGIC
             Only files matching the signature pattern MAGIC are searched.  The
             signature \"magic bytes\" at the start of a file are compared to
@@ -2730,6 +2734,8 @@ source):
             a `/'.  Files and directories explicitly specified as command line
             arguments are never ignored.  This option may be repeated to
             specify additional files.
+            See also related option --exclude-from for a global set of
+            exclusions.
 
 Option `--ignore-files` looks for `.gitignore`, or the specified `FILE`, in
 recursive searches.  When `.gitignore`, or the specified `FILE`, is found while
@@ -2827,6 +2833,8 @@ implicit:
             previously-specified exclusions by including matching files.  Lines
             starting with a `#' and empty lines in FILE are ignored.  When FILE
             is a `-', standard input is read.  This option may be repeated.
+            See also related option --ignore-files for subdirectory-specific
+            lists of exclusions.
     --from=FILE
             Read additional pathnames of files to search from FILE.  When FILE
             is a `-', standard input is read.  This option is useful with `find
@@ -2842,6 +2850,8 @@ implicit:
             a `/'.  Files and directories explicitly specified as command line
             arguments are never ignored.  This option may be repeated to
             specify additional files.
+            See also related option --exclude-from for a global set of
+            exclusions.
     --include=GLOB
             Search only files whose name matches GLOB using wildcard matching,
             same as -g GLOB.  GLOB can use **, *, ?, and [...] as wildcards,
@@ -4320,6 +4330,8 @@ in markdown:
                   files.  Lines starting with a `#' and empty lines in FILE are
                   ignored.  When FILE is a `-', standard input is read.  This option
                   may be repeated.
+                  See also related option --ignore-files for subdirectory-specific
+                  lists of exclusions.
 
            --exclude-fs=MOUNTS
                   Exclude file systems specified by MOUNTS from recursive searches.
@@ -4480,6 +4492,8 @@ in markdown:
                   in a `/'.  Files and directories explicitly specified as command
                   line arguments are never ignored.  This option may be repeated to
                   specify additional files.
+                  See also related option --exclude-from for a global set of
+                  exclusions.
 
            --no-ignore-files
                   Do not ignore files, i.e. cancel --ignore-files when specified.

--- a/man/ug.1
+++ b/man/ug.1
@@ -360,6 +360,8 @@ Otherwise files are excluded.  A glob starting with a `!' overrides
 previously\-specified exclusions by including matching files.  Lines
 starting with a `#' and empty lines in FILE are ignored.  When FILE
 is a `\-', standard input is read.  This option may be repeated.
+See also related option \fB\-\-ignore\-files\fR for subdirectory\-specific
+lists of exclusions.
 .TP
 \fB\-\-exclude\-fs\fR=\fIMOUNTS\fR
 Exclude file systems specified by MOUNTS from recursive searches.
@@ -516,6 +518,8 @@ files.  Directories are specifically excluded when the glob ends in
 a `/'.  Files and directories explicitly specified as command line
 arguments are never ignored.  This option may be repeated to
 specify additional files.
+See also related option \fB\-\-exclude\-from\fR for a global set of
+exclusions.
 .TP
 \fB\-\-no\-ignore\-files\fR
 Do not ignore files, i.e. cancel \fB\-\-ignore\-files\fR when specified.

--- a/man/ugrep.1
+++ b/man/ugrep.1
@@ -360,6 +360,8 @@ Otherwise files are excluded.  A glob starting with a `!' overrides
 previously\-specified exclusions by including matching files.  Lines
 starting with a `#' and empty lines in FILE are ignored.  When FILE
 is a `\-', standard input is read.  This option may be repeated.
+See also related option \fB\-\-ignore\-files\fR for subdirectory\-specific
+lists of exclusions.
 .TP
 \fB\-\-exclude\-fs\fR=\fIMOUNTS\fR
 Exclude file systems specified by MOUNTS from recursive searches.
@@ -516,6 +518,8 @@ files.  Directories are specifically excluded when the glob ends in
 a `/'.  Files and directories explicitly specified as command line
 arguments are never ignored.  This option may be repeated to
 specify additional files.
+See also related option \fB\-\-exclude\-from\fR for a global set of
+exclusions.
 .TP
 \fB\-\-no\-ignore\-files\fR
 Do not ignore files, i.e. cancel \fB\-\-ignore\-files\fR when specified.

--- a/src/ugrep.cpp
+++ b/src/ugrep.cpp
@@ -14034,6 +14034,8 @@ void help(std::ostream& out)
             previously-specified exclusions by including matching files.  Lines\n\
             starting with a `#' and empty lines in FILE are ignored.  When FILE\n\
             is a `-', standard input is read.  This option may be repeated.\n\
+            See also related option --ignore-files for subdirectory-specific\n\
+            lists of exclusions.\n\
     --exclude-fs=MOUNTS\n\
             Exclude file systems specified by MOUNTS from recursive searches.\n\
             MOUNTS is a comma-separated list of mount points or pathnames to\n\
@@ -14184,6 +14186,8 @@ void help(std::ostream& out)
             a `/'.  Files and directories explicitly specified as command line\n\
             arguments are never ignored.  This option may be repeated to\n\
             specify additional files.\n\
+            See also related option --exclude-from for a global set of\n\
+            exclusions.\n\
     --no-ignore-files\n\
             Do not ignore files, i.e. cancel --ignore-files when specified.\n\
     --include=GLOB\n\


### PR DESCRIPTION
As seen in https://github.com/Genivia/ugrep/pull/519#issuecomment-3977530330 and https://github.com/Genivia/ugrep/pull/519#issuecomment-3977606819, a solution to #518 (users puzzled by `ignore-files` while they are in fact looking for `exclude-from`) is to:
1. cross-reference `ignore-files` and `exclude-from` in the doc (`--help` and man page)
    _→ implemented in this PR_
2. warn in case of detectable misuse
    _→ proposed by @genivia-inc for example in https://github.com/Genivia/ugrep/issues/518#issuecomment-3975057010_