### PR TITLE
man: upgrep.1: Do not start lines with ..

### DIFF
--- a/man/ugrep.1
+++ b/man/ugrep.1
@@ -434,7 +434,7 @@ Spacing (blanks and tabs) in regular expressions are ignored.
 \fB\-\-from\fR=\fIFILE\fR
 Read additional pathnames of files to search from FILE.  When FILE
 is a `\-', standard input is read.  This option is useful with `find
-... \fB\-p\fRrint | ugrep \fB\-\-from\fR=\fI\-\fR ...' to search specific files.
+\&... \fB\-p\fRrint | ugrep \fB\-\-from\fR=\fI\-\fR ...' to search specific files.
 .TP
 \fB\-G\fR, \fB\-\-basic\-regexp\fR
 Interpret patterns as basic regular expressions (BREs).


### PR DESCRIPTION
groff thinks that the dual dots at the beginning of a file is a formatting macro. Add a zero-width space.

This fixes this warning:

W: ugrep: groff-message troff:<standard input>:437: warning: name '..' not defined [usr/share/man/man1/ugrep.1.gz:1]