### PR TITLE
Fail fast when DFA position sets exceed complexity limits

### DIFF
--- a/include/reflex/pattern.h
+++ b/include/reflex/pattern.h
@@ -956,12 +956,14 @@ class Pattern {
     static const uint16_t MAX_DEPTH = 256;        ///< analyze DFA up to states this deep to improve predict match
     static const Index MAX_STATES = Const::GMAX/3;///< maximum number of DFA states is constrained by opcode table size
     static const Index MAX_EDGES = 16*Const::GMAX;///< maximum number of DFA edges is constrained by opcode table size
+    static const size_t MAX_POSITIONS = 4194304;  ///< maximum accumulated positions over all DFA states; position sets dominate construction memory when counted repetition overlaps a preceding repeat, so this bounds worst-case memory to fail fast instead of exhausting RAM
     static const Index DEAD_PATH = 1;             ///< state marker "path always and only reaches backedges" (a dead end)
     static const Index KEEP_PATH = MAX_DEPTH;     ///< state marker "required path" (from a newline edge)
     static const Index LOOP_PATH = MAX_DEPTH + 1; ///< state marker "path reaches a backedge" (collect lookback chars)
     DFA()
       :
-        next(ALLOC)
+        next(ALLOC),
+        pno(0)
     { }
     ~DFA()
     {
@@ -974,6 +976,7 @@ class Pattern {
         delete[] *i;
       list.clear();
       next = ALLOC;
+      pno = 0;
     }
 #ifdef WITH_TREE_DFA
     /// new DFA state.
@@ -990,6 +993,7 @@ class Pattern {
     State *state(Positions& pos)
     {
       State *s = state();
+      pno += pos.size();
       s->swap(pos);
       return s;
     }
@@ -1004,6 +1008,7 @@ class Pattern {
     State *state(State *tnode, Positions& pos)
     {
       State *s = state(tnode);
+      pno += pos.size();
       s->swap(pos);
       return s;
     }
@@ -1036,11 +1041,13 @@ class Pattern {
         list.push_back(new State[ALLOC]);
         next = 0;
       }
+      pno += pos.size();
       return list.back()[next++].assign(node, pos);
     }
 #endif
     List     list; ///< block allocation list
     uint16_t next; ///< block allocation, next available slot in last block
+    size_t   pno;  ///< total positions accumulated in DFA states, to check against MAX_POSITIONS
   };
   /// Indexing hash finite state automaton for indexed file search.
   struct HFA {

--- a/lib/pattern.cpp
+++ b/lib/pattern.cpp
@@ -2255,7 +2255,7 @@ void Pattern::compile(
     if (state->accept > 0 && state->accept <= end_.size())
       acc_[state->accept - 1] = true;
     ++vno_;
-    if (vno_ > DFA::MAX_STATES || eno_ > DFA::MAX_EDGES)
+    if (vno_ > DFA::MAX_STATES || eno_ > DFA::MAX_EDGES || dfa_.pno > DFA::MAX_POSITIONS)
       error(regex_error::exceeds_limits, rex_.size());
   }
   delete[] table;


### PR DESCRIPTION
Fixes #555.

`ugrep -G -o '"content":"[^"]*coder[^"]\{0,300\}' /dev/null` allocates 14+ GB over ~95 s before the existing `MAX_STATES` guard trips, because the state-count limit is reached only after millions of DFA states each holding hundreds of iteration-tagged positions — memory grows ~2.5 KB per state while the limit counts states.

## Change

- `DFA` gains a `pno` counter accumulating `pos.size()` in the three `state(..., Positions&)` overloads (both `WITH_TREE_DFA` branches), reset in `clear()`.
- The existing per-state limit check in `Pattern::compile()` additionally raises `regex_error::exceeds_limits` when `pno` passes `DFA::MAX_POSITIONS` (4M).

+9/-2 lines; no change to matching semantics — the counter only feeds the existing error path.

## Sizing evidence for MAX_POSITIONS = 4M

| Pattern | Σ pos.size() |
|---|---|
| 104k-word dictionary via `-f` | ~1 (tree DFA path) |
| 500-word alternation + `[a-z]*` suffix | 5.5k |
| `[0-9]{1,4096}` | 8.2k |
| email / UUID / IP / base64 regexes | 37–1.5k |
| pathological pattern above | >32M and climbing |

Heaviest legitimate measured shape sits ~500x below the cap; the pathological shape blows through it in well under a second.

## Verification

- Pathological pattern: was 14.3 GB / 95 s → now errors `exceeds complexity limits` in **0.59 s at 155 MB** max RSS.
- All patterns in the table above still compile and match correctly.
- `make check`: ALL TESTS PASSED.

Background: Claude Code bundles ugrep as its `grep` replacement, so machine-generated patterns hit this in the wild (anthropics/claude-code#83342 — a host was frozen by one such compile).